### PR TITLE
Improve subscriber layer selection with adaptive simulcast

### DIFF
--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -52,7 +52,11 @@ func (t *SubscribedTrack) UpdateSubscriberSettings(enabled bool, quality livekit
 		t.subMuted.TrySet(!enabled)
 		t.updateDownTrackMute()
 		if enabled && t.dt.Kind() == webrtc.RTPCodecTypeVideo {
-			_ = t.dt.SwitchSpatialLayer(spatialLayerForQuality(quality), true)
+			err := t.dt.SwitchSpatialLayer(spatialLayerForQuality(quality), true)
+			if err == sfu.ErrSpatialLayerNotFound && quality != livekit.VideoQuality_MEDIUM {
+				// try to switch to middle layer
+				_ = t.dt.SwitchSpatialLayer(spatialLayerForQuality(livekit.VideoQuality_MEDIUM), true)
+			}
 		}
 	})
 }


### PR DESCRIPTION
When adaptive-simulcast is used, allow subscribers to switch to the next available layer