### PR TITLE
Propagate err2 if not nil

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -149,7 +149,7 @@ func (r *RoomManager) DeleteRoom(roomName string) error {
 	}()
 
 	wg.Wait()
-	if err != nil {
+	if err2 != nil {
 		err = err2
 	}
 


### PR DESCRIPTION
As far as I can tell, this conditional was meant to propagate `err2` if it's not nil, but as written it tests against `err` instead.