### PR TITLE
Update TLS port default as rfc5766

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -21,6 +21,7 @@ rtc:
   # when set, LiveKit enable WebRTC ICE over TCP when UDP isn't available
   # this port *cannot* be behind load balancer or TLS, and must be exposed on the node
   # WebRTC transports are encrypted and do not require additional encryption
+  # only 80/443 on public IP are allowed if less than 1024
   tcp_port: 7881
   # when set to true, attempts to discover the host's public IP via STUN
   # this is useful for cloud environments such as AWS & Google where hosts have an internal IP
@@ -96,9 +97,10 @@ keys:
 #  # defaults to false
 #  enabled: false
 #  # defaults to 3478 - recommended to 443 if not running HTTP3/QUIC server
+#  # only 53/80/443 are allowed if less than 1024
 #  udp_port: 3478
-#  # defaults to 3478 - if not using a load balancer, this must be set to 443
-#  tls_port: 3478
+#  # defaults to 5349 - if not using a load balancer, this must be set to 443
+#  tls_port: 5349
 #  # needs to match tls cert domain
 #  domain: turn.myhost.com
 #  # optional

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,7 +135,7 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 		},
 		TURN: TURNConfig{
 			Enabled: false,
-			TLSPort: 3478,
+			TLSPort: 5349,
 			UDPPort: 3478,
 		},
 		Keys: map[string]string{},

--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -44,7 +44,6 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 	s := webrtc.SettingEngine{
 		LoggerFactory: logger.LoggerFactory(),
 	}
-	lkLogger := s.LoggerFactory.NewLogger("livekit-mux")
 
 	if externalIP != "" {
 		s.SetNAT1To1IPs([]string{externalIP}, webrtc.ICECandidateTypeHost)
@@ -78,7 +77,7 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 			_ = udpMuxConn.SetWriteBuffer(defaultUDPBufferSize)
 
 			udpMux = ice.NewUDPMuxDefault(ice.UDPMuxParams{
-				Logger:  lkLogger,
+				Logger:  s.LoggerFactory.NewLogger("udp_mux"),
 				UDPConn: udpMuxConn,
 			})
 			s.SetICEUDPMux(udpMux)
@@ -110,7 +109,11 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 			return nil, err
 		}
 
-		tcpMux := webrtc.NewICETCPMux(lkLogger, tcpListener, readBufferSize)
+		tcpMux := webrtc.NewICETCPMux(
+			s.LoggerFactory.NewLogger("tcp_mux"),
+			tcpListener,
+			readBufferSize,
+		)
 		s.SetICETCPMux(tcpMux)
 	}
 


### PR DESCRIPTION
1. TURN TLS port default to 5349 as rfc5766 for port mapping, but still need to be 443 in production
2. Also add comment for allowed ports for TURN UDP and ICE TCP if less than 1024
3. Separate logging scope for tcp/udp mux for debugging, follow pion convention of snake_case (tcp_mux/upd_mux are not being used in pion).