### PR TITLE
Send stun servers to clients

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var DEFAULT_STUN_SERVERS = []string{
+	"stun.l.google.com:19302",
+	"stun1.l.google.com:19302",
+}
+
 type Config struct {
 	Port           uint32            `yaml:"port"`
 	PrometheusPort uint32            `yaml:"prometheus_port"`
@@ -104,12 +109,9 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 			UDPPort:           0,
 			ICEPortRangeStart: 0,
 			ICEPortRangeEnd:   0,
-			StunServers: []string{
-				"stun.l.google.com:19302",
-				"stun1.l.google.com:19302",
-			},
-			MaxBitrate:       3 * 1024 * 1024, // 3 mbps
-			PacketBufferSize: 500,
+			StunServers:       []string{},
+			MaxBitrate:        3 * 1024 * 1024, // 3 mbps
+			PacketBufferSize:  500,
 			PLIThrottle: PLIThrottleConfig{
 				LowQuality:  500 * time.Millisecond,
 				MidQuality:  time.Second,

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -514,10 +514,12 @@ func (r *RoomManager) handleRTCMessage(roomName, identity string, msg *livekit.R
 func (r *RoomManager) iceServersForRoom(ri *livekit.Room) []*livekit.ICEServer {
 	var iceServers []*livekit.ICEServer
 
-	if len(r.rtcConfig.Configuration.ICEServers) > 0 {
-		iceServers = append(iceServers, &livekit.ICEServer{
-			Urls: r.rtcConfig.Configuration.ICEServers[0].URLs,
-		})
+	if len(r.config.RTC.StunServers) > 0 {
+		iceServer := &livekit.ICEServer{}
+		for _, stunServer := range r.config.RTC.StunServers {
+			iceServer.Urls = append(iceServer.Urls, fmt.Sprintf("stun:%s", stunServer))
+		}
+		iceServers = append(iceServers, iceServer)
 	}
 	if r.config.TURN.Enabled {
 		var urls []string


### PR DESCRIPTION
Flutter WebRTC stack requires the presence of STUN servers. For clients that are behind NATs, using STUN would also improve connectivity.