### PR TITLE
support go 1.17 version when use bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,7 @@ fi
 go mod download
 
 GO_VERSION=`go version | { read _ _ v _; echo ${v#go}; }`
-GO_TARGET_VERSION=1.19
+GO_TARGET_VERSION=1.17
 IS_HIGH_VERSION=$(echo $GO_VERSION'>='$GO_TARGET_VERSION | bc -l)
 
 if [ "$IS_HIGH_VERSION" -eq 1 ];

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,9 +26,10 @@ go mod download
 
 GO_VERSION=`go version | { read _ _ v _; echo ${v#go}; }`
 GO_TARGET_VERSION=1.17
-IS_HIGH_VERSION=$(echo $GO_VERSION'>='$GO_TARGET_VERSION | bc -l)
 
-if [ "$IS_HIGH_VERSION" -eq 1 ];
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+if [ $(version $GO_VERSION) -ge $(version $GO_TARGET_VERSION) ];
   then
     go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.0
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,5 +24,15 @@ fi
 
 go mod download
 
-go get -u github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.0
-go get -u google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
+GO_VERSION=`go version | { read _ _ v _; echo ${v#go}; }`
+GO_TARGET_VERSION=1.19
+IS_HIGH_VERSION=$(echo $GO_VERSION'>='$GO_TARGET_VERSION | bc -l)
+
+if [ "$IS_HIGH_VERSION" -eq 1 ];
+  then
+    go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.0
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
+  else
+    go get -u github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.0
+    go get -u google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
+fi


### PR DESCRIPTION
starting with go 1.17, bootstrap.sh is not working because go get command is deprecation
so bootstrap.sh file cannot use on 1.17 version

I fixed bootstrap.sh code for support 1.17