### PR TITLE
roommanager: Add setting to prefer the local node for selection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,9 @@ type RTCConfig struct {
 
 	// Throttle periods for pli/fir rtcp packets
 	PLIThrottle PLIThrottleConfig `yaml:"pli_throttle"`
+
+	// Attempt to create new rooms on this node
+	PreferLocalNode bool `yaml:"prefer_local_node"`
 }
 
 type PLIThrottleConfig struct {
@@ -131,6 +134,7 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 				MidQuality:  time.Second,
 				HighQuality: time.Second,
 			},
+			PreferLocalNode: false,
 		},
 		Audio: AudioConfig{
 			ActiveLevel:     30, // -30dBov = 0.03

--- a/pkg/routing/errors.go
+++ b/pkg/routing/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrIncorrectRTCNode     = errors.New("current node isn't the RTC node for the room")
 	ErrNodeNotFound         = errors.New("could not locate the node")
 	ErrInvalidRouterMessage = errors.New("invalid router message")
+	ErrPrefNodeNotAvailable = errors.New("preferred node not available")
 	ErrChannelClosed        = errors.New("channel closed")
 	ErrChannelFull          = errors.New("channel is full")
 )

--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -69,5 +69,5 @@ type Router interface {
 // NodeSelector selects an appropriate node to run the current session
 //counterfeiter:generate . NodeSelector
 type NodeSelector interface {
-	SelectNode(nodes []*livekit.Node, room *livekit.Room) (*livekit.Node, error)
+	SelectNode(nodes []*livekit.Node, room *livekit.Room, preferredNode *livekit.Node) (*livekit.Node, error)
 }

--- a/pkg/routing/routingfakes/fake_node_selector.go
+++ b/pkg/routing/routingfakes/fake_node_selector.go
@@ -9,11 +9,12 @@ import (
 )
 
 type FakeNodeSelector struct {
-	SelectNodeStub        func([]*livekit.Node, *livekit.Room) (*livekit.Node, error)
+	SelectNodeStub        func([]*livekit.Node, *livekit.Room, *livekit.Node) (*livekit.Node, error)
 	selectNodeMutex       sync.RWMutex
 	selectNodeArgsForCall []struct {
 		arg1 []*livekit.Node
 		arg2 *livekit.Room
+		arg3 *livekit.Node
 	}
 	selectNodeReturns struct {
 		result1 *livekit.Node
@@ -27,7 +28,7 @@ type FakeNodeSelector struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeNodeSelector) SelectNode(arg1 []*livekit.Node, arg2 *livekit.Room) (*livekit.Node, error) {
+func (fake *FakeNodeSelector) SelectNode(arg1 []*livekit.Node, arg2 *livekit.Room, arg3 *livekit.Node) (*livekit.Node, error) {
 	var arg1Copy []*livekit.Node
 	if arg1 != nil {
 		arg1Copy = make([]*livekit.Node, len(arg1))
@@ -38,13 +39,14 @@ func (fake *FakeNodeSelector) SelectNode(arg1 []*livekit.Node, arg2 *livekit.Roo
 	fake.selectNodeArgsForCall = append(fake.selectNodeArgsForCall, struct {
 		arg1 []*livekit.Node
 		arg2 *livekit.Room
-	}{arg1Copy, arg2})
+		arg3 *livekit.Node
+	}{arg1Copy, arg2, arg3})
 	stub := fake.SelectNodeStub
 	fakeReturns := fake.selectNodeReturns
-	fake.recordInvocation("SelectNode", []interface{}{arg1Copy, arg2})
+	fake.recordInvocation("SelectNode", []interface{}{arg1Copy, arg2, arg3})
 	fake.selectNodeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -58,17 +60,17 @@ func (fake *FakeNodeSelector) SelectNodeCallCount() int {
 	return len(fake.selectNodeArgsForCall)
 }
 
-func (fake *FakeNodeSelector) SelectNodeCalls(stub func([]*livekit.Node, *livekit.Room) (*livekit.Node, error)) {
+func (fake *FakeNodeSelector) SelectNodeCalls(stub func([]*livekit.Node, *livekit.Room, *livekit.Node) (*livekit.Node, error)) {
 	fake.selectNodeMutex.Lock()
 	defer fake.selectNodeMutex.Unlock()
 	fake.SelectNodeStub = stub
 }
 
-func (fake *FakeNodeSelector) SelectNodeArgsForCall(i int) ([]*livekit.Node, *livekit.Room) {
+func (fake *FakeNodeSelector) SelectNodeArgsForCall(i int) ([]*livekit.Node, *livekit.Room, *livekit.Node) {
 	fake.selectNodeMutex.RLock()
 	defer fake.selectNodeMutex.RUnlock()
 	argsForCall := fake.selectNodeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeNodeSelector) SelectNodeReturns(result1 *livekit.Node, result2 error) {

--- a/pkg/routing/selectorrandom.go
+++ b/pkg/routing/selectorrandom.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"github.com/livekit/protocol/logger"
 	livekit "github.com/livekit/protocol/proto"
 	"github.com/thoas/go-funk"
 )
@@ -8,12 +9,22 @@ import (
 type RandomSelector struct {
 }
 
-func (s *RandomSelector) SelectNode(nodes []*livekit.Node, room *livekit.Room) (*livekit.Node, error) {
+func (s *RandomSelector) SelectNode(nodes []*livekit.Node, room *livekit.Room, preferredNode *livekit.Node) (*livekit.Node, error) {
 	nodes = GetAvailableNodes(nodes)
 	if len(nodes) == 0 {
 		return nil, ErrNoAvailableNodes
 	}
 
-	idx := funk.RandomInt(0, len(nodes))
-	return nodes[idx], nil
+	if preferredNode != nil && funk.Contains(nodes, func(node *livekit.Node) bool {
+		return node.Id == preferredNode.Id
+	}) {
+		logger.Debugw("selecting preferred node")
+		return preferredNode, nil
+	} else {
+		if preferredNode != nil {
+			logger.Warnw("preferred node not available", ErrPrefNodeNotAvailable)
+		}
+		idx := funk.RandomInt(0, len(nodes))
+		return nodes[idx], nil
+	}
 }

--- a/pkg/routing/selectorsystemload.go
+++ b/pkg/routing/selectorsystemload.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"github.com/livekit/protocol/logger"
 	livekit "github.com/livekit/protocol/proto"
 	"github.com/thoas/go-funk"
 )
@@ -9,7 +10,7 @@ type SystemLoadSelector struct {
 	SysloadLimit float32
 }
 
-func (s *SystemLoadSelector) SelectNode(nodes []*livekit.Node, room *livekit.Room) (*livekit.Node, error) {
+func (s *SystemLoadSelector) SelectNode(nodes []*livekit.Node, room *livekit.Room, preferredNode *livekit.Node) (*livekit.Node, error) {
 	nodes = GetAvailableNodes(nodes)
 	if len(nodes) == 0 {
 		return nil, ErrNoAvailableNodes
@@ -29,6 +30,16 @@ func (s *SystemLoadSelector) SelectNode(nodes []*livekit.Node, room *livekit.Roo
 		nodes = nodesLowLoad
 	}
 
-	idx := funk.RandomInt(0, len(nodes))
-	return nodes[idx], nil
+	if preferredNode != nil && funk.Contains(nodes, func(node *livekit.Node) bool {
+		return node.Id == preferredNode.Id
+	}) {
+		logger.Debugw("selecting preferred node")
+		return preferredNode, nil
+	} else {
+		if preferredNode != nil {
+			logger.Warnw("preferred node not available", ErrPrefNodeNotAvailable)
+		}
+		idx := funk.RandomInt(0, len(nodes))
+		return nodes[idx], nil
+	}
 }

--- a/pkg/routing/selectorsystemload_test.go
+++ b/pkg/routing/selectorsystemload_test.go
@@ -6,12 +6,14 @@ import (
 
 	livekit "github.com/livekit/protocol/proto"
 	"github.com/stretchr/testify/require"
+	"github.com/thoas/go-funk"
 
 	"github.com/livekit/livekit-server/pkg/routing"
 )
 
 var (
 	nodeLoadLow = &livekit.Node{
+		Id: funk.RandomString(8),
 		State: livekit.NodeState_SERVING,
 		Stats: &livekit.NodeStats{
 			UpdatedAt:       time.Now().Unix(),
@@ -21,6 +23,27 @@ var (
 	}
 
 	nodeLoadHigh = &livekit.Node{
+		Id: funk.RandomString(8),
+		State: livekit.NodeState_SERVING,
+		Stats: &livekit.NodeStats{
+			UpdatedAt:       time.Now().Unix(),
+			NumCpus:         1,
+			LoadAvgLast1Min: 2.0,
+		},
+	}
+
+	preferredNodeLoadLow = &livekit.Node{
+		Id: funk.RandomString(8),
+		State: livekit.NodeState_SERVING,
+		Stats: &livekit.NodeStats{
+			UpdatedAt:       time.Now().Unix(),
+			NumCpus:         1,
+			LoadAvgLast1Min: 0.0,
+		},
+	}
+
+	preferredNodeLoadHigh = &livekit.Node{
+		Id: funk.RandomString(8),
 		State: livekit.NodeState_SERVING,
 		Stats: &livekit.NodeStats{
 			UpdatedAt:       time.Now().Unix(),
@@ -34,19 +57,43 @@ func TestSystemLoadSelector_SelectNode(t *testing.T) {
 	selector := routing.SystemLoadSelector{SysloadLimit: 1.0}
 
 	nodes := []*livekit.Node{}
-	_, err := selector.SelectNode(nodes, nil)
+	_, err := selector.SelectNode(nodes, nil, nil)
 	require.Error(t, err, "should error no available nodes")
 
 	// Select a node with high load when no nodes with low load are available
 	nodes = []*livekit.Node{nodeLoadHigh}
-	if _, err := selector.SelectNode(nodes, nil); err != nil {
+	if _, err := selector.SelectNode(nodes, nil, nil); err != nil {
 		t.Error(err)
 	}
 
 	// Select a node with low load when available
 	nodes = []*livekit.Node{nodeLoadLow, nodeLoadHigh}
 	for i := 0; i < 5; i++ {
-		node, err := selector.SelectNode(nodes, nil)
+		node, err := selector.SelectNode(nodes, nil, nil)
+		if err != nil {
+			t.Error(err)
+		}
+		if node != nodeLoadLow {
+			t.Error("selected the wrong node")
+		}
+	}
+
+	// Select a node while preferring a low load node
+	nodes = []*livekit.Node{nodeLoadLow, nodeLoadHigh, preferredNodeLoadLow}
+	for i := 0; i < 5; i++ {
+		node, err := selector.SelectNode(nodes, nil, preferredNodeLoadLow)
+		if err != nil {
+			t.Error(err)
+		}
+		if node != preferredNodeLoadLow {
+			t.Error("selected the wrong node")
+		}
+	}
+
+	// Select a node while preferring a high load node
+	nodes = []*livekit.Node{nodeLoadLow, nodeLoadHigh, preferredNodeLoadHigh}
+	for i := 0; i < 5; i++ {
+		node, err := selector.SelectNode(nodes, nil, preferredNodeLoadHigh)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -112,6 +112,7 @@ func (r *LocalRoomManager) CreateRoom(ctx context.Context, req *livekit.CreateRo
 
 	// select a new node
 	nodeId := req.NodeId
+
 	if nodeId == "" {
 		// select a node for room
 		nodes, err := r.router.ListNodes()
@@ -119,7 +120,14 @@ func (r *LocalRoomManager) CreateRoom(ctx context.Context, req *livekit.CreateRo
 			return nil, err
 		}
 
-		node, err := r.selector.SelectNode(nodes, rm)
+		// Set this node to preferred if local node preferred
+		var preferredNode *livekit.Node
+		if r.config.RTC.PreferLocalNode {
+			logger.Debugw("requesting preferred local node")
+			preferredNode = r.currentNode
+		}
+
+		node, err := r.selector.SelectNode(nodes, rm, preferredNode)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
It may be desired to prefer using the local node when creating a new
room; add a setting that uses the current signaling node when creating a
new room. The availability of the node is still confirmed before
selecting it.

This helps with scenarious where the LiveKit server is being selected
with a regional load balancer to ensure a more distant node isn't
randomly chosen.