### PR TITLE
Restore SetLogger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/gammazero/workerpool v1.1.2
+	github.com/go-logr/logr v1.1.0
 	github.com/go-logr/zapr v1.1.0
 	github.com/go-redis/redis/v8 v8.11.3
 	github.com/google/subcommands v1.2.0 // indirect

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,6 +1,7 @@
 package serverlogger
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/livekit/protocol/logger"
 	"github.com/pion/ion-sfu/pkg/buffer"
@@ -26,6 +27,13 @@ func SetLoggerFactory(lf logging.LoggerFactory) {
 	defaultFactory = lf
 }
 
+// Note: only pass in logr.Logger with default depth
+func SetLogger(l logr.Logger) {
+	logger.SetLogger(l, "livekit")
+	sfu.Logger = l.WithName("sfu")
+	buffer.Logger = sfu.Logger
+}
+
 func InitProduction(logLevel string) {
 	initLogger(zap.NewProductionConfig(), logLevel)
 }
@@ -45,7 +53,5 @@ func initLogger(config zap.Config, level string) {
 
 	l, _ := config.Build()
 	zapLogger := zapr.NewLogger(l)
-	sfu.Logger = zapLogger.WithName("sfu")
-	buffer.Logger = sfu.Logger
-	logger.SetLogger(zapLogger, "livekit")
+	SetLogger(zapLogger)
 }

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/livekit/protocol/logger"
 	livekit "github.com/livekit/protocol/proto"
 	"github.com/livekit/protocol/utils"
@@ -62,7 +63,7 @@ func NewRoom(room *livekit.Room, config WebRTCConfig, iceServers []*livekit.ICES
 		statsReporter:   stats.NewRoomStatsReporter(room.Name),
 		participants:    make(map[string]types.Participant),
 		participantOpts: make(map[string]*ParticipantOptions),
-		bufferFactory:   buffer.NewBufferFactory(config.Receiver.packetBufferSize, logger.GetLogger()),
+		bufferFactory:   buffer.NewBufferFactory(config.Receiver.packetBufferSize, logr.Logger{}),
 	}
 	if r.Room.EmptyTimeout == 0 {
 		r.Room.EmptyTimeout = DefaultEmptyTimeout


### PR DESCRIPTION
- Restore SetLogger to allow alternative logging framework https://github.com/livekit/livekit-server/pull/109
- Fix buffer.NewBufferFactory: logger.GetLogger() has extra depth. Passing empty logger will use default logger set by serverlogger.SetLogger()