### PR TITLE
add api for updating room metadata

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -40,6 +40,8 @@ type Room struct {
 	// time that the last participant left the room
 	leftAt   atomic.Value
 	isClosed utils.AtomicFlag
+	// JSON encoded metadata to pass to clients
+	metadata string
 
 	// for active speaker updates
 	audioConfig *config.AudioConfig
@@ -47,6 +49,7 @@ type Room struct {
 	statsReporter *stats.RoomStatsReporter
 
 	onParticipantChanged func(p types.Participant)
+	onMetadataUpdate     func(r *Room)
 	onClose              func()
 }
 
@@ -298,6 +301,19 @@ func (r *Room) UpdateSubscriptions(participant types.Participant, trackIds []str
 		}
 	}
 	return nil
+}
+
+// SetMetadata attaches metadata to the room
+func (r *Room) SetMetadata(metadata string) {
+	r.metadata = metadata
+
+	if r.onMetadataUpdate != nil {
+		r.onMetadataUpdate(r)
+	}
+}
+
+func (r *Room) OnMetadataUpdate(callback func(*Room)) {
+	r.onMetadataUpdate = callback
 }
 
 // CloseIfEmpty closes the room if all participants had left, or it's still empty past timeout

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -528,6 +528,11 @@ func (r *LocalRoomManager) handleRTCMessage(ctx context.Context, roomName, ident
 		if rm.UpdateParticipant.Permission != nil {
 			participant.SetPermission(rm.UpdateParticipant.Permission)
 		}
+	case *livekit.RTCNodeMessage_UpdateRoom:
+		logger.Debugw("updating room", "room", roomName)
+		if rm.UpdateRoom.Metadata != "" {
+			room.SetMetadata(rm.UpdateRoom.Metadata)
+		}
 	case *livekit.RTCNodeMessage_DeleteRoom:
 		for _, p := range room.GetParticipants() {
 			_ = p.Close()

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -184,6 +184,25 @@ func (s *RoomService) UpdateParticipant(ctx context.Context, req *livekit.Update
 	return participant, nil
 }
 
+func (s *RoomService) UpdateRoom(ctx context.Context, req *livekit.UpdateRoomRequest) (*livekit.RoomInfo, error) {
+	err := s.writeMessage(ctx, req.Room, &livekit.RTCNodeMessage{
+		Message: &livekit.RTCNodeMessage_UpdateRoom{
+			UpdateRoom: req,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	room, err := s.roomManager.LoadRoom(ctx, req.Room)
+	if err != nil {
+		return nil, err
+	}
+
+	room.Metadata = req.Metadata
+	return room, nil
+}
+
 func (s *RoomService) UpdateSubscriptions(ctx context.Context, req *livekit.UpdateSubscriptionsRequest) (*livekit.UpdateSubscriptionsResponse, error) {
 	err := s.writeMessage(ctx, req.Room, req.Identity, &livekit.RTCNodeMessage{
 		Message: &livekit.RTCNodeMessage_UpdateSubscriptions{


### PR DESCRIPTION
I - very naively - copied the `updateParticipant` functions and adapted them for an `updateRoom` api.

Right now this is untested and I'm marking the PR as a draft. Just wanted to give space for feedback early in case I'm going about it entirely wrong.