### PR TITLE
Separate out max layer setting

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -462,6 +462,7 @@ func (t *MediaTrack) GetQualityForDimension(width, height uint32) livekit.VideoQ
 	return quality
 }
 
+// LK-TODO: this should probably left up to auto size management and StreamAllocator
 // this function assumes caller holds lock
 func (t *MediaTrack) shouldStartWithBestQuality() bool {
 	return len(t.subscribedTracks) < 10

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -62,10 +62,17 @@ func (t *SubscribedTrack) UpdateSubscriberSettings(enabled bool, quality livekit
 		t.subMuted.TrySet(!enabled)
 		t.updateDownTrackMute()
 		if enabled && t.dt.Kind() == webrtc.RTPCodecTypeVideo {
-			err := t.dt.SwitchSpatialLayer(spatialLayerForQuality(quality), true)
+			err := t.dt.SetMaxSpatialLayer(spatialLayerForQuality(quality))
+			// LK-TODO-START
+			// For now, this set max calls into switchSpatialLayer and returns the result.
+			// When StreamAllocator becomes the one true way to allocate layers,
+			// there will not a ErrSpatialLayerNotFound error as the allocation
+			// logic will automatically the best available layer under the max layer.
+			// So, this check should be removed when enabling StreamAllocator
+			// LK-TODO-END
 			if err == sfu.ErrSpatialLayerNotFound && quality != livekit.VideoQuality_MEDIUM {
 				// try to switch to middle layer
-				_ = t.dt.SwitchSpatialLayer(spatialLayerForQuality(livekit.VideoQuality_MEDIUM), true)
+				_ = t.dt.SetMaxSpatialLayer(spatialLayerForQuality(livekit.VideoQuality_MEDIUM))
 			}
 		}
 	})

--- a/pkg/service/utils_test.go
+++ b/pkg/service/utils_test.go
@@ -15,10 +15,10 @@ func redisClient() *redis.Client {
 
 func TestIsValidDomain(t *testing.T) {
 	list := map[string]bool{
-		"turn.myhost.com": true,
-		"turn.google.com": true,
+		"turn.myhost.com":  true,
+		"turn.google.com":  true,
 		"https://host.com": false,
-		"turn://host.com": false,
+		"turn://host.com":  false,
 	}
 	for key, result := range list {
 		service.IsValidDomain(key)

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -215,7 +215,7 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 			if dt != nil {
 				if (bestQualityFirst && layer > dt.CurrentSpatialLayer()) ||
 					(!bestQualityFirst && layer < dt.CurrentSpatialLayer()) {
-					_ = dt.SwitchSpatialLayer(layer, false)
+					_ = dt.switchSpatialLayer(layer)
 				}
 			}
 		}
@@ -281,8 +281,6 @@ func (w *WebRTCReceiver) AddDownTrack(track *DownTrack, bestQualityFirst bool) {
 		w.upTrackMu.RUnlock()
 
 		track.SetInitialLayers(int32(layer), 2)
-		track.maxSpatialLayer.set(2)
-		track.maxTemporalLayer.set(2)
 		track.lastSSRC.set(w.SSRC(layer))
 		track.trackType = SimulcastDownTrack
 		track.payload = packetFactory.Get().(*[]byte)


### PR DESCRIPTION
Small step on the way to making StreamAllocator prioritization of tracks.
With the new callback into StreamAllocator, the idea is to use the
max layer information to do track prioritization.

Testing:
--------
Sanity check that sample app works