### PR TITLE
Make VP8 packet translation thread-safe.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -12,6 +12,28 @@ import (
 //
 // Forwarder
 //
+const (
+	InvalidSpatialLayer  = -1
+	InvalidTemporalLayer = -1
+)
+
+type SequenceNumberOrdering int
+
+const (
+	SequenceNumberOrderingContiguous SequenceNumberOrdering = iota
+	SequenceNumberOrderingOutOfOrder
+	SequenceNumberOrderingGap
+	SequenceNumberOrderingDuplicate
+)
+
+type ForwardingStatus int
+
+const (
+	ForwardingStatusOff ForwardingStatus = iota
+	ForwardingStatusPartial
+	ForwardingStatusOptimal
+)
+
 type VideoStreamingChange int
 
 const (


### PR DESCRIPTION
Was using one packet from pool for all VP8 translation which was not thread safe.
Grab packets from the pool when needed for VP8 translation and return to pool after done.
Do not grab packet from pool if the header size between incoming and translated matches.
That also saves copying the packet payload.