### PR TITLE
Improve test CI

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -11,36 +11,47 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/go/bin
-          ~/.cache
-        key: livekit-server
-    - uses: shogo82148/actions-setup-redis@v1.10.3
-      with:
-        redis-version: '6.x'
-        auto-start: true
-    - run: redis-cli ping
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+            ~/.cache
+          key: livekit-server
+      - uses: shogo82148/actions-setup-redis@v1.10.3
+        with:
+          redis-version: '6.x'
+          auto-start: true
+      - run: redis-cli ping
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
 
-    - name: Download Go modules
-      run: go mod download
+      - name: Set up gotestfmt
+        run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
-    - name: Mage Build
-      uses: magefile/mage-action@v1
-      with:
-        version: latest
-        args: build
+      - name: Download Go modules
+        run: go mod download
 
-    - name: Mage Test
-      uses: magefile/mage-action@v1
-      with:
-        version: latest
-        args: testall
+      - name: Mage Build
+        uses: magefile/mage-action@v1
+        with:
+          version: latest
+          args: build
+
+      - name: Test
+        run: |
+          set -euo pipefail
+          go test -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+
+      # Upload the original go test log as an artifact for later review.
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-log
+          path: /tmp/gotest.log
+          if-no-files-found: error

--- a/magefile.go
+++ b/magefile.go
@@ -117,7 +117,7 @@ func PublishDocker() error {
 // run unit tests, skipping integration
 func Test() error {
 	mg.Deps(generateWire)
-	cmd := exec.Command("go", "test", "-short", "./...")
+	cmd := exec.Command("go", "test", "-v", "-short", "./...")
 	connectStd(cmd)
 	return cmd.Run()
 }
@@ -126,7 +126,7 @@ func Test() error {
 func TestAll() error {
 	mg.Deps(generateWire)
 	// "-v", "-race",
-	cmd := exec.Command("go", "test", "./...", "-count=1", "-timeout=4m")
+	cmd := exec.Command("go", "test", "-v", "./...", "-count=1", "-timeout=4m")
 	connectStd(cmd)
 	return cmd.Run()
 }

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -241,7 +241,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName string, pi rout
 		Hidden:          pi.Hidden,
 		Logger:          pLogger,
 	})
-	
+
 	if err != nil {
 		logger.Errorw("could not create participant", err)
 		return

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -241,6 +241,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName string, pi rout
 		Hidden:          pi.Hidden,
 		Logger:          pLogger,
 	})
+	
 	if err != nil {
 		logger.Errorw("could not create participant", err)
 		return

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/livekit/protocol/auth"
-	livekit "github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/utils"
 	"github.com/pion/turn/v2"
@@ -183,7 +183,7 @@ func (s *LivekitServer) Start() error {
 	go s.backgroundWorker()
 
 	// give time for Serve goroutine to start
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	s.running.TrySet(true)
 


### PR DESCRIPTION
Using gotestfmt in CI output to make failures easier to identify. Gave server a bit more time to start to improve test reliability on slower machines.