### PR TITLE
Fix forwarding status deduction

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -287,11 +287,15 @@ func (f *Forwarder) GetForwardingStatus() ForwardingStatus {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
+	if f.muted || len(f.availableLayers) == 0 {
+		return ForwardingStatusOptimal
+	}
+
 	if f.targetLayers == InvalidLayers {
 		return ForwardingStatusOff
 	}
 
-	if f.targetLayers.spatial < f.maxLayers.spatial {
+	if f.targetLayers.spatial < f.maxLayers.spatial && f.targetLayers.spatial < int32(f.availableLayers[len(f.availableLayers)-1]) {
 		return ForwardingStatusPartial
 	}
 


### PR DESCRIPTION
- When muted OR when there are no available layers, declare optimal
- When target layer is the maximum it can achieve taking available
  layers into account even if they are not the maximum subscribed layer,
  it is still optimal as there is nothing better available.