### PR TITLE
fix panic in forwarder

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -602,7 +602,7 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition() VideoTransitio
 	minimalLayers := InvalidLayers
 	bandwidthRequired := int64(0)
 	for s := int32(0); s <= f.maxLayers.spatial; s++ {
-		for t := int32(0); s <= f.maxLayers.temporal; t++ {
+		for t := int32(0); t <= f.maxLayers.temporal; t++ {
 			if f.provisional.bitrates[s][t] != 0 {
 				minimalLayers = VideoLayers{spatial: s, temporal: t}
 				bandwidthRequired = f.provisional.bitrates[s][t]


### PR DESCRIPTION
panic: runtime error: index out of range [4] with length 4

goroutine 564 [running]:
github.com/livekit/livekit-server/pkg/sfu.(*Forwarder).ProvisionalAllocateGetCooperativeTransition(0xc0004d9600)
	/Users/rauberder/projects/livekit-server/pkg/sfu/forwarder.go:606 +0x295
github.com/livekit/livekit-server/pkg/sfu.(*DownTrack).ProvisionalAllocateGetCooperativeTransition(...)
	/Users/rauberder/projects/livekit-server/pkg/sfu/downtrack.go:539
github.com/livekit/livekit-server/pkg/sfu.(*Track).ProvisionalAllocateGetCooperativeTransition(...)
	/Users/rauberder/projects/livekit-server/pkg/sfu/streamallocator.go:1084
github.com/livekit/livekit-server/pkg/sfu.(*StreamAllocator).allocateTrack(0xc00092ca20, 0xc000235260)
	/Users/rauberder/projects/livekit-server/pkg/sfu/streamallocator.go:648 +0x41a
github.com/livekit/livekit-server/pkg/sfu.(*StreamAllocator).handleSignalAvailableLayersChange(0xc00092ca20, 0xc0003dff01)
	/Users/rauberder/projects/livekit-server/pkg/sfu/streamallocator.go:508 +0x4b
github.com/livekit/livekit-server/pkg/sfu.(*StreamAllocator).handleEvent(0xc00092ca20, 0xc0003dff78)
	/Users/rauberder/projects/livekit-server/pkg/sfu/streamallocator.go:318 +0x71
github.com/livekit/livekit-server/pkg/sfu.(*StreamAllocator).processEvents(0xc00092ca20)
	/Users/rauberder/projects/livekit-server/pkg/sfu/streamallocator.go:279 +0x7a
created by github.com/livekit/livekit-server/pkg/sfu.(*StreamAllocator).Start
	/Users/rauberder/projects/livekit-server/pkg/sfu/streamallocator.go:161 +0x5f