### PR TITLE
Implement event loop for telemetry service

### DIFF
--- a/pkg/telemetry/telemetryserviceinternal.go
+++ b/pkg/telemetry/telemetryserviceinternal.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"sync"
 
 	"github.com/gammazero/workerpool"
 	"github.com/livekit/protocol/livekit"
@@ -26,7 +25,6 @@ type telemetryServiceInternal struct {
 	notifier    webhook.Notifier
 	webhookPool *workerpool.WorkerPool
 
-	sync.RWMutex
 	// one worker per participant
 	workers map[string]*StatsWorker
 
@@ -43,18 +41,14 @@ func NewTelemetryServiceInternal(notifier webhook.Notifier, analytics AnalyticsS
 }
 
 func (t *telemetryServiceInternal) AddUpTrack(participantID string, trackID string, buff *buffer.Buffer) {
-	t.RLock()
 	w := t.workers[participantID]
-	t.RUnlock()
 	if w != nil {
 		w.AddBuffer(trackID, buff)
 	}
 }
 
 func (t *telemetryServiceInternal) OnDownstreamPacket(participantID string, trackID string, bytes int) {
-	t.RLock()
 	w := t.workers[participantID]
-	t.RUnlock()
 	if w != nil {
 		w.OnDownstreamPacket(trackID, bytes)
 	}
@@ -90,9 +84,7 @@ func (t *telemetryServiceInternal) HandleRTCP(streamType livekit.StreamType, par
 
 	prometheus.IncrementRTCP(direction, stats.NackCount, stats.PliCount, stats.FirCount)
 
-	t.RLock()
 	w := t.workers[participantID]
-	t.RUnlock()
 	if w != nil {
 		w.OnRTCP(trackID, streamType, stats)
 	}

--- a/pkg/telemetry/telemetryserviceinternalevents.go
+++ b/pkg/telemetry/telemetryserviceinternalevents.go
@@ -46,9 +46,7 @@ func (t *telemetryServiceInternal) RoomEnded(ctx context.Context, room *livekit.
 
 func (t *telemetryServiceInternal) ParticipantJoined(ctx context.Context, room *livekit.Room,
 	participant *livekit.ParticipantInfo, clientInfo *livekit.ClientInfo) {
-	t.Lock()
 	t.workers[participant.Sid] = newStatsWorker(ctx, t, room.Sid, room.Name, participant.Sid)
-	t.Unlock()
 
 	prometheus.AddParticipant()
 
@@ -70,12 +68,10 @@ func (t *telemetryServiceInternal) ParticipantJoined(ctx context.Context, room *
 }
 
 func (t *telemetryServiceInternal) ParticipantLeft(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo) {
-	t.Lock()
 	if w := t.workers[participant.Sid]; w != nil {
 		w.Close()
 		delete(t.workers, participant.Sid)
 	}
-	t.Unlock()
 
 	prometheus.SubParticipant()
 
@@ -111,9 +107,7 @@ func (t *telemetryServiceInternal) TrackPublished(ctx context.Context, participa
 func (t *telemetryServiceInternal) TrackUnpublished(ctx context.Context, participantID string, track *livekit.TrackInfo, ssrc uint32) {
 	roomID := ""
 	roomName := ""
-	t.RLock()
 	w := t.workers[participantID]
-	t.RUnlock()
 	if w != nil {
 		roomID = w.roomID
 		w.RemoveBuffer(track.GetSid())
@@ -189,9 +183,7 @@ func (t *telemetryServiceInternal) RecordingEnded(ctx context.Context, ri *livek
 }
 
 func (t *telemetryServiceInternal) getRoomDetails(participantID string) (string, string) {
-	t.RLock()
 	w := t.workers[participantID]
-	t.RUnlock()
 	if w != nil {
 		return w.roomID, w.roomName
 	}


### PR DESCRIPTION
It allows all actions/events to run in the same go routine.
Therefore no synchronisation primitives are needed inside
telemetry service implementation.