### PR TITLE
A simple configuration for congestion control.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,12 +65,19 @@ type RTCConfig struct {
 
 	// Which side runs bandwidth estimation
 	UseSendSideBWE bool `yaml:"send_side_bandwidth_estimation"`
+
+	CongestionControl CongestionControlConfig `yaml:"congestion_control"`
 }
 
 type PLIThrottleConfig struct {
 	LowQuality  time.Duration `yaml:"low_quality"`
 	MidQuality  time.Duration `yaml:"mid_quality"`
 	HighQuality time.Duration `yaml:"high_quality"`
+}
+
+type CongestionControlConfig struct {
+	Enabled    bool `yaml:"enabled"`
+	AllowPause bool `yaml:"allow_pause"`
 }
 
 type AudioConfig struct {
@@ -157,6 +164,10 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 				LowQuality:  500 * time.Millisecond,
 				MidQuality:  time.Second,
 				HighQuality: time.Second,
+			},
+			CongestionControl: CongestionControlConfig{
+				Enabled:    true,
+				AllowPause: true,
 			},
 		},
 		Audio: AudioConfig{

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -36,19 +36,20 @@ const (
 )
 
 type ParticipantParams struct {
-	Identity        livekit.ParticipantIdentity
-	Name            livekit.ParticipantName
-	SID             livekit.ParticipantID
-	Config          *WebRTCConfig
-	Sink            routing.MessageSink
-	AudioConfig     config.AudioConfig
-	ProtocolVersion types.ProtocolVersion
-	Telemetry       telemetry.TelemetryService
-	ThrottleConfig  config.PLIThrottleConfig
-	EnabledCodecs   []*livekit.Codec
-	Hidden          bool
-	Recorder        bool
-	Logger          logger.Logger
+	Identity                livekit.ParticipantIdentity
+	Name                    livekit.ParticipantName
+	SID                     livekit.ParticipantID
+	Config                  *WebRTCConfig
+	Sink                    routing.MessageSink
+	AudioConfig             config.AudioConfig
+	ProtocolVersion         types.ProtocolVersion
+	Telemetry               telemetry.TelemetryService
+	ThrottleConfig          config.PLIThrottleConfig
+	CongestionControlConfig config.CongestionControlConfig
+	EnabledCodecs           []*livekit.Codec
+	Hidden                  bool
+	Recorder                bool
+	Logger                  logger.Logger
 }
 
 type ParticipantImpl struct {
@@ -114,25 +115,27 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 		return nil, err
 	}
 	p.publisher, err = NewPCTransport(TransportParams{
-		ParticipantID:       p.params.SID,
-		ParticipantIdentity: p.params.Identity,
-		Target:              livekit.SignalTarget_PUBLISHER,
-		Config:              params.Config,
-		Telemetry:           p.params.Telemetry,
-		EnabledCodecs:       p.params.EnabledCodecs,
-		Logger:              params.Logger,
+		ParticipantID:           p.params.SID,
+		ParticipantIdentity:     p.params.Identity,
+		Target:                  livekit.SignalTarget_PUBLISHER,
+		Config:                  params.Config,
+		CongestionControlConfig: params.CongestionControlConfig,
+		Telemetry:               p.params.Telemetry,
+		EnabledCodecs:           p.params.EnabledCodecs,
+		Logger:                  params.Logger,
 	})
 	if err != nil {
 		return nil, err
 	}
 	p.subscriber, err = NewPCTransport(TransportParams{
-		ParticipantID:       p.params.SID,
-		ParticipantIdentity: p.params.Identity,
-		Target:              livekit.SignalTarget_SUBSCRIBER,
-		Config:              params.Config,
-		Telemetry:           p.params.Telemetry,
-		EnabledCodecs:       p.params.EnabledCodecs,
-		Logger:              params.Logger,
+		ParticipantID:           p.params.SID,
+		ParticipantIdentity:     p.params.Identity,
+		Target:                  livekit.SignalTarget_SUBSCRIBER,
+		Config:                  params.Config,
+		CongestionControlConfig: params.CongestionControlConfig,
+		Telemetry:               p.params.Telemetry,
+		EnabledCodecs:           p.params.EnabledCodecs,
+		Logger:                  params.Logger,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -229,18 +229,19 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 	sid := utils.NewGuid(utils.ParticipantPrefix)
 	pLogger := rtc.LoggerWithParticipant(room.Logger, pi.Identity, sid)
 	participant, err = rtc.NewParticipant(rtc.ParticipantParams{
-		Identity:        pi.Identity,
-		Name:            pi.Name,
-		SID:             sid,
-		Config:          &rtcConf,
-		Sink:            responseSink,
-		AudioConfig:     r.config.Audio,
-		ProtocolVersion: pv,
-		Telemetry:       r.telemetry,
-		ThrottleConfig:  r.config.RTC.PLIThrottle,
-		EnabledCodecs:   room.Room.EnabledCodecs,
-		Hidden:          pi.Hidden,
-		Logger:          pLogger,
+		Identity:                pi.Identity,
+		Name:                    pi.Name,
+		SID:                     sid,
+		Config:                  &rtcConf,
+		Sink:                    responseSink,
+		AudioConfig:             r.config.Audio,
+		ProtocolVersion:         pv,
+		Telemetry:               r.telemetry,
+		ThrottleConfig:          r.config.RTC.PLIThrottle,
+		CongestionControlConfig: r.config.RTC.CongestionControl,
+		EnabledCodecs:           room.Room.EnabledCodecs,
+		Hidden:                  pi.Hidden,
+		Logger:                  pLogger,
 	})
 
 	if err != nil {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -4,12 +4,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
 	"io"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
 
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
@@ -544,16 +545,16 @@ func (d *DownTrack) DistanceToDesired() int32 {
 	return d.forwarder.DistanceToDesired()
 }
 
-func (d *DownTrack) Allocate(availableChannelCapacity int64) VideoAllocation {
-	return d.forwarder.Allocate(availableChannelCapacity, d.receiver.GetBitrateTemporalCumulative())
+func (d *DownTrack) Allocate(availableChannelCapacity int64, allowPause bool) VideoAllocation {
+	return d.forwarder.Allocate(availableChannelCapacity, allowPause, d.receiver.GetBitrateTemporalCumulative())
 }
 
 func (d *DownTrack) ProvisionalAllocatePrepare() {
 	d.forwarder.ProvisionalAllocatePrepare(d.receiver.GetBitrateTemporalCumulative())
 }
 
-func (d *DownTrack) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers) int64 {
-	return d.forwarder.ProvisionalAllocate(availableChannelCapacity, layers)
+func (d *DownTrack) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers, allowPause bool) int64 {
+	return d.forwarder.ProvisionalAllocate(availableChannelCapacity, layers, allowPause)
 }
 
 func (d *DownTrack) ProvisionalAllocateGetCooperativeTransition() VideoTransition {

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -360,7 +360,7 @@ func (f *Forwarder) DistanceToDesired() int32 {
 	return f.lastAllocation.distanceToDesired
 }
 
-func (f *Forwarder) Allocate(availableChannelCapacity int64, brs Bitrates) VideoAllocation {
+func (f *Forwarder) Allocate(availableChannelCapacity int64, allowPause bool, brs Bitrates) VideoAllocation {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -399,14 +399,18 @@ func (f *Forwarder) Allocate(availableChannelCapacity int64, brs Bitrates) Video
 					change = VideoStreamingChangeResuming
 				}
 			} else {
-				// disable forwarding as it is not known how big this stream is
-				// and if it will fit in the available channel capacity
-				f.currentLayers = InvalidLayers
+				if !allowPause {
+					// when pause is disallowed, pick the lowest available
+					targetLayers.spatial = int32(math.Min(float64(f.maxLayers.spatial), float64(f.availableLayers[0])))
+					targetLayers.temporal = int32(math.Min(0, float64(f.maxLayers.temporal)))
+				} else {
+					// disable forwarding as it is not known how big this stream is
+					// and if it will fit in the available channel capacity
+					state = VideoAllocationStateDeficient
 
-				state = VideoAllocationStateDeficient
-
-				if f.targetLayers != InvalidLayers {
-					change = VideoStreamingChangePausing
+					if f.targetLayers != InvalidLayers {
+						change = VideoStreamingChangePausing
+					}
 				}
 			}
 		}
@@ -445,8 +449,35 @@ func (f *Forwarder) Allocate(availableChannelCapacity int64, brs Bitrates) Video
 		if bandwidthRequested == 0 {
 			state = VideoAllocationStateDeficient
 
-			if f.targetLayers != InvalidLayers {
-				change = VideoStreamingChangePausing
+			if !allowPause {
+				// find the lowest layer to prevent pausing
+				for s := int32(0); s <= f.maxLayers.spatial; s++ {
+					for t := int32(0); t <= f.maxLayers.temporal; t++ {
+						if brs[s][t] == 0 {
+							continue
+						}
+
+						targetLayers = VideoLayers{
+							spatial:  s,
+							temporal: t,
+						}
+
+						bandwidthRequested = brs[s][t]
+
+						if f.targetLayers == InvalidLayers {
+							change = VideoStreamingChangeResuming
+						}
+						break
+					}
+
+					if bandwidthRequested != 0 {
+						break
+					}
+				}
+			} else {
+				if f.targetLayers != InvalidLayers {
+					change = VideoStreamingChangePausing
+				}
 			}
 		}
 	}
@@ -480,7 +511,7 @@ func (f *Forwarder) ProvisionalAllocatePrepare(bitrates Bitrates) {
 	}
 }
 
-func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers) int64 {
+func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers, allowPause bool) int64 {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -503,6 +534,12 @@ func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layers V
 	}
 
 	if requiredBitrate <= (availableChannelCapacity + alreadyAllocatedBitrate) {
+		f.provisional.layers = layers
+		return requiredBitrate
+	}
+
+	// when pause is disallowed, pick the layer if none allocated already or something lower is available
+	if !allowPause && (f.provisional.layers == InvalidLayers || !layers.GreaterThan(f.provisional.layers)) {
 		f.provisional.layers = layers
 		return requiredBitrate
 	}


### PR DESCRIPTION
Two settings
  - `enabled` - defaults to true - set to false to disable congestion
    control
  - `allow_pause` - defaults to true - when congestion control is
    enabled, this controls if streams are allowed to pause or not. When
    pausing is not allowed, the lowest available layer is streamed where
    otherwise it should have really been paused to avoid congestion.