### PR TITLE
Fix missed update when subscribers are subscribing to the same layer

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -353,7 +353,7 @@ func (t *MediaTrack) AddSubscriber(sub types.Participant) error {
 	t.receiver.AddDownTrack(downTrack)
 	// since sub will lock, run it in a goroutine to avoid deadlocks
 	go func() {
-		t.NotifySubscriberMaxQuality(subscriberID, livekit.VideoQuality_HIGH) // start with HIGH, let subscription change it later
+		t.NotifySubscriberMaxQuality(subscriberID, livekit.VideoQuality_MEDIUM) // start with MEDIUM, let subscription change it later
 		sub.AddSubscribedTrack(subTrack)
 		sub.Negotiate()
 	}()
@@ -915,25 +915,17 @@ func (t *MediaTrack) updateQualityChange() {
 			}
 		}
 	} else {
-		t.allSubscribersMuted = false
-		if maxSubscribedQuality != t.maxSubscribedQuality {
+		if t.allSubscribersMuted || maxSubscribedQuality != t.maxSubscribedQuality {
+			t.allSubscribersMuted = false
 			notifyMaxExpected = true
 			maxExpectedSpatialLayer = SpatialLayerForQuality(maxSubscribedQuality)
-
 			t.maxSubscribedQuality = maxSubscribedQuality
 
-			subscribedQualities = append(subscribedQualities, &livekit.SubscribedQuality{Quality: livekit.VideoQuality_LOW, Enabled: true})
-
-			if t.maxSubscribedQuality == livekit.VideoQuality_LOW {
-				subscribedQualities = append(subscribedQualities, &livekit.SubscribedQuality{Quality: livekit.VideoQuality_MEDIUM, Enabled: false})
-			} else {
-				subscribedQualities = append(subscribedQualities, &livekit.SubscribedQuality{Quality: livekit.VideoQuality_MEDIUM, Enabled: true})
-			}
-
-			if t.maxSubscribedQuality != livekit.VideoQuality_HIGH {
-				subscribedQualities = append(subscribedQualities, &livekit.SubscribedQuality{Quality: livekit.VideoQuality_HIGH, Enabled: false})
-			} else {
-				subscribedQualities = append(subscribedQualities, &livekit.SubscribedQuality{Quality: livekit.VideoQuality_HIGH, Enabled: true})
+			for q := livekit.VideoQuality_LOW; q <= livekit.VideoQuality_HIGH; q++ {
+				subscribedQualities = append(subscribedQualities, &livekit.SubscribedQuality{
+					Quality: q,
+					Enabled: q <= t.maxSubscribedQuality,
+				})
 			}
 		}
 	}

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -353,7 +353,7 @@ func (t *MediaTrack) AddSubscriber(sub types.Participant) error {
 	t.receiver.AddDownTrack(downTrack)
 	// since sub will lock, run it in a goroutine to avoid deadlocks
 	go func() {
-		t.NotifySubscriberMaxQuality(subscriberID, livekit.VideoQuality_MEDIUM) // start with MEDIUM, let subscription change it later
+		t.NotifySubscriberMaxQuality(subscriberID, livekit.VideoQuality_HIGH) // start with HIGH, let subscription change it later
 		sub.AddSubscribedTrack(subTrack)
 		sub.Negotiate()
 	}()

--- a/pkg/rtc/mediatrack_test.go
+++ b/pkg/rtc/mediatrack_test.go
@@ -236,5 +236,14 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		}
 		require.Equal(t, "v1", actualTrackID)
 		require.EqualValues(t, expectedSubscribedQualities, actualSubscribedQualities)
+
+		// unmuting "s1" should enable previously set max quality
+		mt.NotifySubscriberMaxQuality("s1", livekit.VideoQuality_LOW)
+		expectedSubscribedQualities = []*livekit.SubscribedQuality{
+			{Quality: livekit.VideoQuality_LOW, Enabled: true},
+			{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
+			{Quality: livekit.VideoQuality_HIGH, Enabled: false},
+		}
+		require.EqualValues(t, expectedSubscribedQualities, actualSubscribedQualities)
 	})
 }


### PR DESCRIPTION
When subscribers unsubscribe and then re-subscribe to the same layer, the update was missed since `maxSubscribedQuality` did not change.