### PR TITLE
sfu node always pick ice controlled role(lite)

### DIFF
--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -62,6 +62,7 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 	s := webrtc.SettingEngine{
 		LoggerFactory: serverlogger.LoggerFactory(),
 	}
+	s.SetLite(true)
 
 	if externalIP != "" {
 		s.SetNAT1To1IPs([]string{externalIP}, webrtc.ICECandidateTypeHost)

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -127,6 +127,7 @@ func NewRTCClient(conn *websocket.Conn) (*RTCClient, error) {
 		Configuration: rtcConf,
 	}
 	conf.SettingEngine.SetLite(false)
+	conf.SettingEngine.SetAnsweringDTLSRole(webrtc.DTLSRoleClient)
 	codecs := []*livekit.Codec{
 		{
 			Mime: "audio/opus",

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -126,6 +126,7 @@ func NewRTCClient(conn *websocket.Conn) (*RTCClient, error) {
 	conf := rtc.WebRTCConfig{
 		Configuration: rtcConf,
 	}
+	conf.SettingEngine.SetLite(false)
 	codecs := []*livekit.Codec{
 		{
 			Mime: "audio/opus",


### PR DESCRIPTION
during session migration, there are case that both client and server pick ice-controlling role that will cause role conflict, can't establish ice connection. In RFC, there are solution for ice role conflict, looks chrome and pion not work as RFC described, need time to dig into it. Let sfu node pick ice-controlled role to solve this(ice lite)