### PR TITLE
Prevent multiple resume notifications on track

### DIFF
--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -227,7 +227,7 @@ func TestForwarderAllocate(t *testing.T) {
 	}
 	expectedResult = VideoAllocation{
 		state:              VideoAllocationStateAwaitingMeasurement,
-		change:             VideoStreamingChangeNone,
+		change:             VideoStreamingChangeResuming,
 		bandwidthRequested: 0,
 		bandwidthDelta:     0,
 		availableLayers:    []uint16{0},

--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -687,10 +687,13 @@ func (s *StreamAllocator) maybeCommitEstimate() (isDecreasing bool) {
 		s.lastEstimateDecreaseTime = time.Now()
 		isDecreasing = true
 	}
+
+	if s.committedChannelCapacity > s.receivedEstimate {
+		s.params.Logger.Debugw("committing channel capacity(bps)", "from", s.committedChannelCapacity, "to", s.receivedEstimate)
+	}
 	s.committedChannelCapacity = s.receivedEstimate
 	s.lastCommitTime = time.Now()
 
-	s.params.Logger.Debugw("committing channel capacity", "capacity(bps)", s.committedChannelCapacity)
 	return
 }
 


### PR DESCRIPTION
When returning previous allocation as is, reset change to none.
Ideally, would like to have change as a separate return and not in last
allocation. But, also prefer to have last allocation state. For now,
resetting change.