### PR TITLE
fix close on nil sink

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -464,7 +464,9 @@ func (p *ParticipantImpl) Close(sendLeave bool) error {
 
 	// ensure this is synchronized
 	p.lock.RLock()
-	p.params.Sink.Close()
+	if p.params.Sink != nil {
+		p.params.Sink.Close()
+	}
 	onClose := p.onClose
 	p.lock.RUnlock()
 	if onClose != nil {


### PR DESCRIPTION
ParticipantImpl.params.sink will be closed and  set nil when cloud process SimulateScenario_Migration, need to check nil in ParticipantImpl.close 

> panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x10384c254]
> 
> goroutine 83 [running]:
> github.com/livekit/livekit-server/pkg/rtc.(*ParticipantImpl).Close(0x140003a6d80, 0x1)
> 	/Users/rauberder/go/pkg/mod/github.com/livekit/livekit-server@v0.15.3-0.20220115014945-416ca80a8b34/pkg/rtc/participant.go:467 +0x454
> github.com/livekit/cloud/pkg/rtc.(*Room).RemoveLocalParticipant(0x140007cf180, {0x103d2b4d8, 0x14000a5aff0}, {0x140002d7af8, 0x6})
> 	/Users/rauberder/projects/livekit-cloud/pkg/rtc/room_local.go:156 +0x1e4
> github.com/livekit/cloud/pkg/rtc.(*Room).CreateOrUpdateRemoteParticipant(0x140007cf180, {0x103d2b4d8, 0x14000a5ab10}, 0x14000dc92c0, {0x0, 0xed976d685, 0x104533200})
> 	/Users/rauberder/projects/livekit-cloud/pkg/rtc/room_remote.go:54 +0x3fc
> github.com/livekit/cloud/pkg/service.(*RoomManager).HandleRoomRTCMessage(0x1400050c360, 0x140003ead20)
> 	/Users/rauberder/projects/livekit-cloud/pkg/service/roommanager_messag:128 +0x7e0
> github.com/livekit/cloud/pkg/routing.(*Router).messageHandler(0x14000514000, 0x14000666060)
> 	/Users/rauberder/projects/livekit-cloud/pkg/routing/router_handler.go:73 +0x6c4
> created by github.com/livekit/cloud/pkg/routing.(*Router).Start
> 	/Users/rauberder/projects/livekit-cloud/pkg/routing/router.go:107 +0xb8