### PR TITLE
refine reuse transceiver

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1489,15 +1489,17 @@ func (p *ParticipantImpl) rtcpSendWorker() {
 
 		fwdPkts := make([]rtcp.Packet, 0, len(pkts))
 		for _, pkt := range pkts {
-			switch pkt.(type) {
+			switch packet := pkt.(type) {
 			case *rtcp.PictureLossIndication:
-				mediaSSRC := pkt.(*rtcp.PictureLossIndication).MediaSSRC
+				mediaSSRC := packet.MediaSSRC
 				if p.pliThrottle.canSend(mediaSSRC) {
+					p.params.Logger.Debugw("send pli", "ssrc", mediaSSRC)
 					fwdPkts = append(fwdPkts, pkt)
 				}
 			case *rtcp.FullIntraRequest:
-				mediaSSRC := pkt.(*rtcp.FullIntraRequest).MediaSSRC
+				mediaSSRC := packet.MediaSSRC
 				if p.pliThrottle.canSend(mediaSSRC) {
+					p.params.Logger.Debugw("send fir", "ssrc", mediaSSRC)
 					fwdPkts = append(fwdPkts, pkt)
 				}
 			default:


### PR DESCRIPTION

In case of session migration that RemoteParticipant transit to LocalParticipant, the video track will cost ~20s to resume render. 
1. Client A -> Node A, Client B -> Node B
2. B migrate to Node A
3. Pariticipant of Client B in Node A transit to local from remote, Client A remove remote B's track then add local B's track to resume subscribe tracks.
4. Client A cost ~20s for B's video to resume(get black screen because we send it on DownTrack's Close)

That is because we use 'go dt.Close' when remove Subscriber, and call pc's RemoveTrack on dt.OnCloseHandle. That cause AddTrack and RemoteTrack happens sametime and transceiver is not reused as expect. In this case, client A will get  Subscribe SDP like:

> v=0
...
// remote participant B's tracks
m=audio
a=recvonly   <- we want this to be resued for resume tracks
m=video
a=recvonly   <- we want this to be resued for resume tracks
// local participant B's tracks
m=audio
a=senrecv
m=video
a=sendrecv