### PR TITLE
Do not send connection quality when participant is not active.

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -831,6 +831,10 @@ func (r *Room) connectionQualityWorker() {
 		connectionInfos := make(map[livekit.ParticipantID]*livekit.ConnectionQualityInfo, len(participants))
 
 		for _, p := range participants {
+			if p.State() != livekit.ParticipantInfo_ACTIVE {
+				continue
+			}
+
 			connectionInfos[p.ID()] = p.GetConnectionQuality()
 		}
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -835,7 +835,7 @@ func (r *Room) connectionQualityWorker() {
 		}
 
 		for _, op := range participants {
-			if !op.ProtocolVersion().SupportsConnectionQuality() {
+			if !op.ProtocolVersion().SupportsConnectionQuality() || op.State() != livekit.ParticipantInfo_ACTIVE {
 				continue
 			}
 			update := &livekit.ConnectionQualityUpdate{}


### PR DESCRIPTION
Some times when the connection takes a while (in a long delay network
on Safari for example), connection quality arrives before connectivity.

Not entirely sure if we should do this, but it bothered me when debugging long delay connections. If this is okay, will make the same change on cloud side too.