### PR TITLE
Fire onNoSubscribers callback in only one place.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -263,8 +263,6 @@ func (t *MediaTrackSubscriptions) RemoveSubscriber(participantID livekit.Partici
 	if subTrack != nil {
 		subTrack.DownTrack().CloseWithFlush(!resume)
 	}
-
-	t.maybeNotifyNoSubscribers()
 }
 
 func (t *MediaTrackSubscriptions) RemoveAllSubscribers() {
@@ -278,8 +276,6 @@ func (t *MediaTrackSubscriptions) RemoveAllSubscribers() {
 	for _, subTrack := range subscribedTracks {
 		subTrack.DownTrack().Close()
 	}
-
-	t.maybeNotifyNoSubscribers()
 }
 
 func (t *MediaTrackSubscriptions) RevokeDisallowedSubscribers(allowedSubscriberIDs []livekit.ParticipantID) []livekit.ParticipantID {


### PR DESCRIPTION
While reworking some cloud code, this is getting fired multiple times
(in RemoveAllSubscriber and in the callback). So, it causes some
errors in the logs. Fire it only from one place.