### PR TITLE
Ensure RoomService operation is complete prior to returning

### DIFF
--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -65,6 +65,9 @@ func (r *StandardRoomAllocator) CreateRoom(ctx context.Context, req *livekit.Cre
 	if req.MaxParticipants > 0 {
 		rm.MaxParticipants = req.MaxParticipants
 	}
+	if req.Metadata != "" {
+		rm.Metadata = req.Metadata
+	}
 	if err := r.roomStore.StoreRoom(ctx, rm); err != nil {
 		return nil, err
 	}

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -397,10 +397,14 @@ func (r *RoomManager) handleRTCMessage(_ context.Context, roomName livekit.RoomN
 	}
 
 	participant := room.GetParticipant(identity)
+	var sid livekit.ParticipantID
+	if participant != nil {
+		sid = participant.ID()
+	}
 	pLogger := rtc.LoggerWithParticipant(
 		rtc.LoggerWithRoom(logger.Logger(logger.GetLogger()), roomName, room.ID()),
 		identity,
-		"",
+		sid,
 	)
 
 	switch rm := msg.Message.(type) {

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -556,6 +556,16 @@ func (c *RTCClient) PublishData(data []byte, kind livekit.DataPacket_Kind) error
 	}
 }
 
+func (c *RTCClient) GetPublishedTrackIDs() []string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	var trackIDs []string
+	for key, _ := range c.localTracks {
+		trackIDs = append(trackIDs, key)
+	}
+	return trackIDs
+}
+
 func (c *RTCClient) ensurePublisherConnected() error {
 	if c.publisherConnected.Get() {
 		return nil

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -258,6 +258,16 @@ func createRoomToken() string {
 	return t
 }
 
+func adminRoomToken(name string) string {
+	at := auth.NewAccessToken(testApiKey, testApiSecret).
+		AddGrant(&auth.VideoGrant{RoomAdmin: true, Room: name})
+	t, err := at.ToJWT()
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
 func listRoomToken() string {
 	at := auth.NewAccessToken(testApiKey, testApiSecret).
 		AddGrant(&auth.VideoGrant{RoomList: true})

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -101,7 +101,11 @@ func waitForServerToStart(s *service.LivekitServer) {
 			panic("could not start server after timeout")
 		case <-time.After(10 * time.Millisecond):
 			if s.IsRunning() {
-				return
+				// ensure we can connect to it
+				res, err := http.Get(fmt.Sprintf("http://localhost:%d", s.HTTPPort()))
+				if err == nil && res.StatusCode == http.StatusOK {
+					return
+				}
 			}
 		}
 	}

--- a/test/multinode_roomservice_test.go
+++ b/test/multinode_roomservice_test.go
@@ -1,0 +1,153 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/livekit/livekit-server/pkg/testutils"
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiNodeRoomList(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+	_, _, finish := setupMultiNodeTest("TestMultiNodeRoomList")
+	defer finish()
+
+	roomServiceListRoom(t)
+}
+
+// update room metadata when it's empty
+func TestMultiNodeUpdateRoomMetadata(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	t.Run("when room is empty", func(t *testing.T) {
+		_, _, finish := setupMultiNodeTest("TestMultiNodeUpdateRoomMetadata_empty")
+		defer finish()
+
+		_, err := roomClient.CreateRoom(contextWithToken(createRoomToken()), &livekit.CreateRoomRequest{
+			Name: "emptyRoom",
+		})
+		require.NoError(t, err)
+
+		rm, err := roomClient.UpdateRoomMetadata(contextWithToken(adminRoomToken("emptyRoom")), &livekit.UpdateRoomMetadataRequest{
+			Room:     "emptyRoom",
+			Metadata: "updated metadata",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "updated metadata", rm.Metadata)
+	})
+
+	t.Run("when room has a participant", func(t *testing.T) {
+		_, _, finish := setupMultiNodeTest("TestMultiNodeUpdateRoomMetadata_with_participant")
+		defer finish()
+
+		c1 := createRTCClient("c1", defaultServerPort, nil)
+		waitUntilConnected(t, c1)
+		defer c1.Stop()
+
+		_, err := roomClient.CreateRoom(contextWithToken(createRoomToken()), &livekit.CreateRoomRequest{
+			Name: "emptyRoom",
+		})
+		require.NoError(t, err)
+
+		rm, err := roomClient.UpdateRoomMetadata(contextWithToken(adminRoomToken("emptyRoom")), &livekit.UpdateRoomMetadataRequest{
+			Room:     "emptyRoom",
+			Metadata: "updated metadata",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "updated metadata", rm.Metadata)
+	})
+}
+
+// remove a participant
+func TestMultiNodeRemoveParticipant(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	_, _, finish := setupMultiNodeTest("TestMultiNodeRemoveParticipant")
+	defer finish()
+
+	c1 := createRTCClient("mn_remove_participant", defaultServerPort, nil)
+	defer c1.Stop()
+	waitUntilConnected(t, c1)
+
+	ctx := contextWithToken(adminRoomToken(testRoom))
+	_, err := roomClient.RemoveParticipant(ctx, &livekit.RoomParticipantIdentity{
+		Room:     testRoom,
+		Identity: "mn_remove_participant",
+	})
+	require.NoError(t, err)
+
+	// participant list doesn't show the participant
+	listRes, err := roomClient.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+		Room: testRoom,
+	})
+	require.NoError(t, err)
+	require.Len(t, listRes.Participants, 0)
+}
+
+// update participant metadata
+func TestMultiNodeUpdateParticipantMetadata(t *testing.T) {
+	_, _, finish := setupMultiNodeTest("TestMultiNodeUpdateParticipantMetadata")
+	defer finish()
+
+	c1 := createRTCClient("update_participant_metadata", defaultServerPort, nil)
+	defer c1.Stop()
+	waitUntilConnected(t, c1)
+
+	ctx := contextWithToken(adminRoomToken(testRoom))
+	res, err := roomClient.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+		Room:     testRoom,
+		Identity: "update_participant_metadata",
+		Metadata: "the new metadata",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "the new metadata", res.Metadata)
+}
+
+// admin mute published track
+func TestMultiNodeMutePublishedTrack(t *testing.T) {
+	_, _, finish := setupMultiNodeTest("TestMultiNodeMutePublishedTrack")
+	defer finish()
+
+	identity := "mute_published_track"
+	c1 := createRTCClient(identity, defaultServerPort, nil)
+	defer c1.Stop()
+	waitUntilConnected(t, c1)
+
+	// c1 and c2 publishing, c3 just receiving
+	writers := publishTracksForClients(t, c1)
+	defer stopWriters(writers...)
+
+	trackIDs := c1.GetPublishedTrackIDs()
+	require.NotEmpty(t, trackIDs)
+
+	ctx := contextWithToken(adminRoomToken(testRoom))
+	// wait for it to be published before
+	testutils.WithTimeout(t, "ensure track is published", func() bool {
+		res, err := roomClient.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
+			Room:     testRoom,
+			Identity: identity,
+		})
+		require.NoError(t, err)
+		return len(res.Tracks) == 2
+	})
+
+	res, err := roomClient.MutePublishedTrack(ctx, &livekit.MuteRoomTrackRequest{
+		Room:     testRoom,
+		Identity: identity,
+		TrackSid: trackIDs[0],
+		Muted:    true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, trackIDs[0], res.Track.Sid)
+	require.True(t, res.Track.Muted)
+}

--- a/test/multinode_test.go
+++ b/test/multinode_test.go
@@ -141,17 +141,6 @@ func TestMultinodeDataPublishing(t *testing.T) {
 	scenarioDataPublish(t)
 }
 
-func TestMultiNodeRoomList(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-		return
-	}
-	_, _, finish := setupMultiNodeTest("TestMultiNodeRoomList")
-	defer finish()
-
-	roomServiceListRoom(t)
-}
-
 func TestMultiNodeJoinAfterClose(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -162,27 +151,4 @@ func TestMultiNodeJoinAfterClose(t *testing.T) {
 	defer finish()
 
 	scenarioJoinClosedRoom(t)
-}
-
-func TestMultiNodeUpdateEmptyRoomMetadata(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-		return
-	}
-
-	// update room metadata when it's empty
-	_, _, finish := setupMultiNodeTest("TestMultiNodeUpdateEmptyRoomMetadata")
-	defer finish()
-
-	_, err := roomClient.CreateRoom(contextWithToken(createRoomToken()), &livekit.CreateRoomRequest{
-		Name: "emptyRoom",
-	})
-	require.NoError(t, err)
-
-	rm, err := roomClient.UpdateRoomMetadata(contextWithToken(adminRoomToken("emptyRoom")), &livekit.UpdateRoomMetadataRequest{
-		Room:     "emptyRoom",
-		Metadata: "updated metadata",
-	})
-	require.NoError(t, err)
-	require.Equal(t, "updated metadata", rm.Metadata)
 }

--- a/test/multinode_test.go
+++ b/test/multinode_test.go
@@ -163,3 +163,26 @@ func TestMultiNodeJoinAfterClose(t *testing.T) {
 
 	scenarioJoinClosedRoom(t)
 }
+
+func TestMultiNodeUpdateEmptyRoomMetadata(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	// update room metadata when it's empty
+	_, _, finish := setupMultiNodeTest("TestMultiNodeUpdateEmptyRoomMetadata")
+	defer finish()
+
+	_, err := roomClient.CreateRoom(contextWithToken(createRoomToken()), &livekit.CreateRoomRequest{
+		Name: "emptyRoom",
+	})
+	require.NoError(t, err)
+
+	rm, err := roomClient.UpdateRoomMetadata(contextWithToken(adminRoomToken("emptyRoom")), &livekit.UpdateRoomMetadataRequest{
+		Room:     "emptyRoom",
+		Metadata: "updated metadata",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "updated metadata", rm.Metadata)
+}


### PR DESCRIPTION
When running in multi-node, we would fire off the request and return a response before the operation has been successful. 

This could lead to clients expecting the effect after the call, but then failing to see it.

It'll now confirm that the operation had been taken prior to returning a response; and it'll also reflect failures correctly.

Fixes #338, #196 