### PR TITLE
fix concurrency problem

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -48,6 +48,8 @@ type MediaTrack struct {
 	*MediaTrackReceiver
 
 	onMediaLossUpdate func(trackID livekit.TrackID, fractionalLoss uint32)
+
+	lock sync.RWMutex
 }
 
 type MediaTrackParams struct {
@@ -204,6 +206,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 		}
 	})
 
+	t.lock.Lock()
 	if t.Receiver() == nil {
 		wr := sfu.NewWebRTCReceiver(
 			receiver,
@@ -226,6 +229,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 
 		t.MediaTrackReceiver.SetupReceiver(wr)
 	}
+	t.lock.Unlock()
 
 	t.Receiver().(*sfu.WebRTCReceiver).AddUpTrack(track, buff)
 	t.params.Telemetry.AddUpTrack(t.PublisherID(), t.ID(), buff)


### PR DESCRIPTION
close of closed channel

> goroutine 2106 [running]:github.com/livekit/livekit-server/pkg/rtc.(*MediaTrack).closeChan(...)/Users/rauberder/projects/livekit-server/pkg/rtc/mediatrack.go:331github.com/livekit/livekit-server/pkg/rtc.(*MediaTrackReceiver).Close(0x14000182f00)/Users/rauberder/projects/livekit-server/pkg/rtc/mediatrackreceiver.go:105 +0xa8github.com/livekit/livekit-server/pkg/rtc.(*MediaTrack).AddReceiver.func4()/Users/rauberder/projects/livekit-server/pkg/rtc/mediatrack.go:206 +0x50github.com/livekit/livekit-server/pkg/sfu.(*WebRTCReceiver).closeTracks(0x14000558780)/Users/rauberder/projects/livekit-server/pkg/sfu/receiver.go:562 +0x114github.com/livekit/livekit-server/pkg/sfu.(*WebRTCReceiver).forwardRTP.func1.1()/Users/rauberder/projects/livekit-server/pkg/sfu/receiver.go:474 +0x5csync.(*Once).doSlow(0x14000558840, 0x1400020e6a8)/usr/local/go/src/sync/once.go:68 +0x10csync.(*Once).Do(...)/usr/local/go/src/sync/once.go:59github.com/livekit/livekit-server/pkg/sfu.(*WebRTCReceiver).forwardRTP.func1(0x14000558780, 0x14000248000, 0x1)/Users/rauberder/projects/livekit-server/pkg/sfu/receiver.go:472 +0x58github.com/livekit/livekit-server/pkg/sfu.(*WebRTCReceiver).forwardRTP(0x14000558780, 0x1)/Users/rauberder/projects/livekit-server/pkg/sfu/receiver.go:491 +0x478created by github.com/livekit/livekit-server/pkg/sfu.(*WebRTCReceiver).AddUpTrack/Users/rauberder/projects/livekit-server/pkg/sfu/receiver.go:200 +0x178