### PR TITLE
Add a method to clear receiver.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -90,6 +90,14 @@ func (t *MediaTrackReceiver) SetupReceiver(receiver sfu.TrackReceiver) {
 	t.MediaTrackSubscriptions.Start()
 }
 
+func (t *MediaTrackReceiver) ClearReceiver() {
+	t.lock.Lock()
+	t.receiver = nil
+	t.lock.Unlock()
+
+	t.MediaTrackSubscriptions.Close()
+}
+
 func (t *MediaTrackReceiver) OnMediaLossUpdate(f func(fractionalLoss uint8)) {
 	t.onMediaLossUpdate = f
 }


### PR DESCRIPTION
With remote media track receiver starting/stopping/restarting possibly,
receiver should be cleared when stopped and will be re-initialized when
it is restarted.