### PR TITLE
Delete down track on close

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -453,9 +453,12 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 
 	d.closeOnce.Do(func() {
 		Logger.V(1).Info("Closing sender", "peer_id", d.peerID, "kind", d.kind)
+		d.receiver.DeleteDownTrack(d.peerID)
+
 		if d.onCloseHandler != nil {
 			d.onCloseHandler()
 		}
+
 		close(d.done)
 	})
 }


### PR DESCRIPTION
Note that it is called from Unbind also (previous behaviour). It should
be fine as long as there is no new down track for the same peer added
between close calling it and unbind calling it.