### PR TITLE
Honor autoSubscribe when subscription permissions are granted later

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -417,6 +417,9 @@ func (r *Room) SetParticipantPermission(participant types.LocalParticipant, perm
 	if !hadCanSubscribe && participant.CanSubscribe() {
 		if participant.State() == livekit.ParticipantInfo_ACTIVE {
 			r.subscribeToExistingTracks(participant)
+			// start negotiating regardless of if there are other media tracks to subscribe
+			// we'll need to set the participant up to receive data
+			participant.Negotiate()
 		}
 	}
 	return nil

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -410,6 +410,18 @@ func (r *Room) RemoveDisallowedSubscriptions(sub types.LocalParticipant, disallo
 	}
 }
 
+func (r *Room) SetParticipantPermission(participant types.LocalParticipant, permission *livekit.ParticipantPermission) error {
+	hadCanSubscribe := participant.CanSubscribe()
+	participant.SetPermission(permission)
+	// when subscribe perms are given, trigger autosub
+	if !hadCanSubscribe && participant.CanSubscribe() {
+		if participant.State() == livekit.ParticipantInfo_ACTIVE {
+			r.subscribeToExistingTracks(participant)
+		}
+	}
+	return nil
+}
+
 func (r *Room) UpdateVideoLayers(participant types.Participant, updateVideoLayers *livekit.UpdateVideoLayers) error {
 	return participant.UpdateVideoLayers(updateVideoLayers)
 }

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -161,7 +161,7 @@ type Room interface {
 	UpdateSubscriptionPermission(participant LocalParticipant, permissions *livekit.SubscriptionPermission) error
 	SyncState(participant LocalParticipant, state *livekit.SyncState) error
 	SimulateScenario(participant LocalParticipant, scenario *livekit.SimulateScenario) error
-
+	SetParticipantPermission(participant LocalParticipant, permission *livekit.ParticipantPermission) error
 	UpdateVideoLayers(participant Participant, updateVideoLayers *livekit.UpdateVideoLayers) error
 }
 

--- a/pkg/rtc/types/typesfakes/fake_room.go
+++ b/pkg/rtc/types/typesfakes/fake_room.go
@@ -29,6 +29,18 @@ type FakeRoom struct {
 	nameReturnsOnCall map[int]struct {
 		result1 livekit.RoomName
 	}
+	SetParticipantPermissionStub        func(types.LocalParticipant, *livekit.ParticipantPermission) error
+	setParticipantPermissionMutex       sync.RWMutex
+	setParticipantPermissionArgsForCall []struct {
+		arg1 types.LocalParticipant
+		arg2 *livekit.ParticipantPermission
+	}
+	setParticipantPermissionReturns struct {
+		result1 error
+	}
+	setParticipantPermissionReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SimulateScenarioStub        func(types.LocalParticipant, *livekit.SimulateScenario) error
 	simulateScenarioMutex       sync.RWMutex
 	simulateScenarioArgsForCall []struct {
@@ -198,6 +210,68 @@ func (fake *FakeRoom) NameReturnsOnCall(i int, result1 livekit.RoomName) {
 	}
 	fake.nameReturnsOnCall[i] = struct {
 		result1 livekit.RoomName
+	}{result1}
+}
+
+func (fake *FakeRoom) SetParticipantPermission(arg1 types.LocalParticipant, arg2 *livekit.ParticipantPermission) error {
+	fake.setParticipantPermissionMutex.Lock()
+	ret, specificReturn := fake.setParticipantPermissionReturnsOnCall[len(fake.setParticipantPermissionArgsForCall)]
+	fake.setParticipantPermissionArgsForCall = append(fake.setParticipantPermissionArgsForCall, struct {
+		arg1 types.LocalParticipant
+		arg2 *livekit.ParticipantPermission
+	}{arg1, arg2})
+	stub := fake.SetParticipantPermissionStub
+	fakeReturns := fake.setParticipantPermissionReturns
+	fake.recordInvocation("SetParticipantPermission", []interface{}{arg1, arg2})
+	fake.setParticipantPermissionMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRoom) SetParticipantPermissionCallCount() int {
+	fake.setParticipantPermissionMutex.RLock()
+	defer fake.setParticipantPermissionMutex.RUnlock()
+	return len(fake.setParticipantPermissionArgsForCall)
+}
+
+func (fake *FakeRoom) SetParticipantPermissionCalls(stub func(types.LocalParticipant, *livekit.ParticipantPermission) error) {
+	fake.setParticipantPermissionMutex.Lock()
+	defer fake.setParticipantPermissionMutex.Unlock()
+	fake.SetParticipantPermissionStub = stub
+}
+
+func (fake *FakeRoom) SetParticipantPermissionArgsForCall(i int) (types.LocalParticipant, *livekit.ParticipantPermission) {
+	fake.setParticipantPermissionMutex.RLock()
+	defer fake.setParticipantPermissionMutex.RUnlock()
+	argsForCall := fake.setParticipantPermissionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeRoom) SetParticipantPermissionReturns(result1 error) {
+	fake.setParticipantPermissionMutex.Lock()
+	defer fake.setParticipantPermissionMutex.Unlock()
+	fake.SetParticipantPermissionStub = nil
+	fake.setParticipantPermissionReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRoom) SetParticipantPermissionReturnsOnCall(i int, result1 error) {
+	fake.setParticipantPermissionMutex.Lock()
+	defer fake.setParticipantPermissionMutex.Unlock()
+	fake.SetParticipantPermissionStub = nil
+	if fake.setParticipantPermissionReturnsOnCall == nil {
+		fake.setParticipantPermissionReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setParticipantPermissionReturnsOnCall[i] = struct {
+		result1 error
 	}{result1}
 }
 
@@ -530,6 +604,8 @@ func (fake *FakeRoom) Invocations() map[string][][]interface{} {
 	defer fake.iDMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
+	fake.setParticipantPermissionMutex.RLock()
+	defer fake.setParticipantPermissionMutex.RUnlock()
 	fake.simulateScenarioMutex.RLock()
 	defer fake.simulateScenarioMutex.RUnlock()
 	fake.syncStateMutex.RLock()

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -248,7 +248,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 		Grants:                  pi.Grants,
 		Hidden:                  pi.Hidden,
 		Logger:                  pLogger,
-	})
+	}, pi.Permission)
 	if err != nil {
 		logger.Errorw("could not create participant", err)
 		return
@@ -256,9 +256,6 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 
 	if pi.Metadata != "" {
 		participant.SetMetadata(pi.Metadata)
-	}
-	if pi.Permission != nil {
-		participant.SetPermission(pi.Permission)
 	}
 
 	// join room
@@ -461,7 +458,10 @@ func (r *RoomManager) handleRTCMessage(_ context.Context, roomName livekit.RoomN
 			participant.SetMetadata(rm.UpdateParticipant.Metadata)
 		}
 		if rm.UpdateParticipant.Permission != nil {
-			participant.SetPermission(rm.UpdateParticipant.Permission)
+			err := room.SetParticipantPermission(participant, rm.UpdateParticipant.Permission)
+			if err != nil {
+				pLogger.Errorw("could not update permissions", err)
+			}
 		}
 	case *livekit.RTCNodeMessage_DeleteRoom:
 		for _, p := range room.GetParticipants() {

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -89,7 +89,7 @@ type Options struct {
 }
 
 func NewWebSocketConn(host, token string, opts *Options) (*websocket.Conn, error) {
-	u, err := url.Parse(host + "/rtc?protocol=3")
+	u, err := url.Parse(host + "/rtc?protocol=6")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If a participant joins the room without the ability to subscribe, but then gets those permissions later. We should honor their autosubscribe setting and trigger a subscribe cycle.