### PR TITLE
Refactoring connection stats

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -730,21 +730,21 @@ func (p *ParticipantImpl) GetAudioLevel() (level uint8, active bool) {
 
 func (p *ParticipantImpl) GetConnectionQuality() *livekit.ConnectionQualityInfo {
 	// avg loss across all tracks, weigh published the same as subscribed
-	scores, numTracks := p.getPublisherConnectionQuality()
+	totalScore, numTracks := p.getPublisherConnectionQuality()
 
 	p.lock.RLock()
 	for _, subTrack := range p.subscribedTracks {
 		if subTrack.IsMuted() || subTrack.MediaTrack().IsMuted() {
 			continue
 		}
-		scores += subTrack.DownTrack().GetConnectionScore()
+		totalScore += subTrack.DownTrack().GetConnectionScore()
 		numTracks++
 	}
 	p.lock.RUnlock()
 
 	avgScore := 5.0
 	if numTracks > 0 {
-		avgScore = scores / float64(numTracks)
+		avgScore = totalScore / float64(numTracks)
 	}
 
 	rating := connectionquality.Score2Rating(avgScore)
@@ -1328,12 +1328,12 @@ func (p *ParticipantImpl) setTrackMuted(trackID livekit.TrackID, muted bool) {
 	}
 }
 
-func (p *ParticipantImpl) getPublisherConnectionQuality() (scores float64, numTracks int) {
+func (p *ParticipantImpl) getPublisherConnectionQuality() (totalScore float64, numTracks int) {
 	for _, pt := range p.GetPublishedTracks() {
 		if pt.IsMuted() {
 			continue
 		}
-		scores += pt.(types.LocalMediaTrack).GetConnectionScore()
+		totalScore += pt.(types.LocalMediaTrack).GetConnectionScore()
 		numTracks++
 	}
 

--- a/pkg/rtc/utils.go
+++ b/pkg/rtc/utils.go
@@ -45,11 +45,6 @@ func UnpackDataTrackLabel(packed string) (peerID livekit.ParticipantID, trackID 
 	return
 }
 
-// converts a fixed point number to the number part of %
-func FixedPointToPercent(frac uint8) uint32 {
-	return (uint32(frac) * 100) >> 8
-}
-
 func ToProtoParticipants(participants []types.LocalParticipant) []*livekit.ParticipantInfo {
 	infos := make([]*livekit.ParticipantInfo, 0, len(participants))
 	for _, op := range participants {

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -101,7 +101,7 @@ type Stats struct {
 	LostRate     float32
 	PacketCount  uint32  // Number of packets received from this source.
 	Jitter       float64 // An estimate of the statistical variance of the RTP data packet inter-arrival time.
-	TotalByte    uint64
+	TotalBytes   uint64
 }
 
 // BufferOptions provides configuration options for the buffer
@@ -313,7 +313,7 @@ func (b *Buffer) calc(pkt []byte, arrivalTime int64) {
 		}
 	}
 
-	b.stats.TotalByte += uint64(len(pkt))
+	b.stats.TotalBytes += uint64(len(pkt))
 	b.stats.PacketCount++
 
 	ep := ExtPacket{
@@ -458,7 +458,7 @@ func (b *Buffer) buildREMBPacket() *rtcp.ReceiverEstimatedMaximumBitrate {
 	if br < 100000 {
 		br = 100000
 	}
-	b.stats.TotalByte = 0
+	b.stats.TotalBytes = 0
 
 	return &rtcp.ReceiverEstimatedMaximumBitrate{
 		Bitrate: float32(br),
@@ -481,9 +481,9 @@ func (b *Buffer) buildReceptionReport() rtcp.ReceptionReport {
 
 	lostInterval := expectedInterval - receivedInterval
 
-	b.stats.LostRate = float32(lostInterval) / float32(expectedInterval)
 	var fracLost uint8
-	if expectedInterval != 0 && lostInterval > 0 {
+	if expectedInterval != 0 {
+		b.stats.LostRate = float32(lostInterval) / float32(expectedInterval)
 		fracLost = uint8((lostInterval << 8) / expectedInterval)
 	}
 	if b.lastFractionLostToReport > fracLost {

--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -1,57 +1,205 @@
 package connectionquality
 
-import "sync"
+import (
+	"sync"
+	"time"
 
-type ConnectionStat struct {
-	PacketsLost  uint32
-	TotalPackets uint32
-	LastSeqNum   uint32
-	TotalBytes   uint64
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/utils"
+	"github.com/pion/rtcp"
+	"github.com/pion/webrtc/v3"
+)
+
+type Snapshot struct {
+	Initialized      bool
+	TotalPacketsLost uint32
+	HighestSeqNum    uint32
+}
+
+type ConnectionStatsParams struct {
+	UpdateInterval      time.Duration
+	CodecType           webrtc.RTPCodecType
+	GetTotalBytes       func() uint64
+	GetIsReducedQuality func() bool
 }
 
 type ConnectionStats struct {
-	Lock sync.Mutex
-	ConnectionStat
-	Prev      *ConnectionStat
-	Delay     uint32
-	Jitter    uint32
-	NackCount int32
-	PliCount  int32
-	FirCount  int32
-	Score     float64
+	lock sync.RWMutex
+
+	params ConnectionStatsParams
+
+	baseSeqNumInitialized bool
+	baseSeqNum            uint32
+	highestSeqNum         uint32
+	totalPacketsLost      uint32
+	totalBytes            uint64
+
+	snapshot Snapshot
+
+	maxDelay  uint32
+	maxJitter uint32
+
+	nackCount int32
+	pliCount  int32
+	firCount  int32
+
+	score float64
+
+	onStatsUpdate func(cs *ConnectionStats, stat *livekit.AnalyticsStat)
+
+	done     chan struct{}
+	isClosed utils.AtomicFlag
 }
 
-func NewConnectionStats() *ConnectionStats {
-	return &ConnectionStats{Prev: &ConnectionStat{}, Score: 4.0}
+func NewConnectionStats(params ConnectionStatsParams) *ConnectionStats {
+	return &ConnectionStats{
+		params: params,
+		score:  4.0,
+		done:   make(chan struct{}),
+	}
 }
 
-func getTotalPackets(curSN, prevSN uint32) uint32 {
-	delta := curSN - prevSN
-	// lower 16 bits is the counter
-	counter := uint16(delta)
-	// upper 16 bits contains the cycles/wrap
-	cycles := uint16(delta >> 16)
-	increment := (uint32(cycles) * (1 << 16)) + uint32(counter)
-
-	return increment
+func (cs *ConnectionStats) Start() {
+	go cs.updateStats()
 }
 
-func (cs *ConnectionStats) UpdateStats(totalBytes uint64) ConnectionStat {
-	// update feedback stats
-	previous := cs.Prev
+func (cs *ConnectionStats) Close() {
+	if !cs.isClosed.TrySet(true) {
+		return
+	}
 
-	// Update TotalPackets from SeqNum here
-	cs.TotalPackets += getTotalPackets(cs.LastSeqNum, previous.LastSeqNum)
-	cs.TotalBytes = totalBytes
+	close(cs.done)
+}
 
-	var delta ConnectionStat
+func (cs *ConnectionStats) OnStatsUpdate(fn func(cs *ConnectionStats, stat *livekit.AnalyticsStat)) {
+	cs.onStatsUpdate = fn
+}
 
-	delta.TotalPackets = cs.TotalPackets - previous.TotalPackets
-	delta.PacketsLost = cs.PacketsLost - previous.PacketsLost
-	delta.TotalBytes = cs.TotalBytes - previous.TotalBytes
+func (cs *ConnectionStats) RTCPFeedback(packets []rtcp.Packet, expectedSSRC uint32) {
+	if cs.isClosed.Get() {
+		return
+	}
 
-	// store previous stats
-	cs.Prev = &ConnectionStat{TotalPackets: cs.TotalPackets, PacketsLost: cs.PacketsLost, TotalBytes: cs.TotalBytes, LastSeqNum: cs.LastSeqNum}
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
 
-	return delta
+	for _, p := range packets {
+		switch pkt := p.(type) {
+		case *rtcp.ReceiverReport:
+			for _, r := range pkt.Reports {
+				if expectedSSRC != 0 && r.SSRC != expectedSSRC {
+					continue
+				}
+
+				if r.Delay > cs.maxDelay {
+					cs.maxDelay = r.Delay
+				}
+
+				if r.Jitter > cs.maxJitter {
+					cs.maxJitter = r.Jitter
+				}
+
+				if !cs.baseSeqNumInitialized {
+					cs.baseSeqNumInitialized = true
+					cs.baseSeqNum = r.LastSequenceNumber
+					cs.highestSeqNum = r.LastSequenceNumber
+					cs.totalPacketsLost = r.TotalLost
+				}
+
+				if r.LastSequenceNumber > cs.highestSeqNum {
+					cs.highestSeqNum = r.LastSequenceNumber
+					cs.totalPacketsLost = r.TotalLost
+				}
+			}
+
+		case *rtcp.TransportLayerNack:
+			nackCount := 0
+			for _, pair := range pkt.Nacks {
+				nackCount += len(pair.PacketList())
+			}
+			cs.nackCount += int32(nackCount)
+
+		case *rtcp.PictureLossIndication:
+			cs.pliCount += 1
+
+		case *rtcp.FullIntraRequest:
+			cs.firCount += 1
+		}
+	}
+}
+
+func (cs *ConnectionStats) GetScore() float64 {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.score
+}
+
+func (cs *ConnectionStats) updateAndGetPercentageLoss() float64 {
+	if cs.params.GetTotalBytes != nil {
+		cs.totalBytes = cs.params.GetTotalBytes()
+	}
+
+	if !cs.snapshot.Initialized {
+		cs.snapshot.Initialized = true
+		cs.snapshot.HighestSeqNum = cs.highestSeqNum
+		cs.snapshot.TotalPacketsLost = cs.totalPacketsLost
+	}
+
+	packetsLostInInterval := cs.totalPacketsLost - cs.snapshot.TotalPacketsLost
+	expectedPacketsInInterval := cs.highestSeqNum - cs.snapshot.HighestSeqNum
+	percentageLoss := float64(0.0)
+	if expectedPacketsInInterval > 0 {
+		percentageLoss = (float64(packetsLostInInterval) / float64(expectedPacketsInInterval)) * 100
+	}
+
+	cs.snapshot.HighestSeqNum = cs.highestSeqNum
+	cs.snapshot.TotalPacketsLost = cs.totalPacketsLost
+
+	return percentageLoss
+}
+
+func (cs *ConnectionStats) updateStats() {
+	tk := time.NewTicker(cs.params.UpdateInterval)
+	for {
+		select {
+		case <-cs.done:
+			return
+
+		case <-tk.C:
+			cs.lock.Lock()
+			pctLoss := cs.updateAndGetPercentageLoss()
+			if cs.params.CodecType == webrtc.RTPCodecTypeAudio {
+				cs.score = AudioConnectionScore(pctLoss, cs.maxJitter)
+			} else {
+				isReducedQuality := false
+				if cs.params.GetIsReducedQuality != nil {
+					isReducedQuality = cs.params.GetIsReducedQuality()
+				}
+				cs.score = VideoConnectionScore(pctLoss, isReducedQuality)
+			}
+
+			totalPacketsReceived := uint32(0)
+			if cs.baseSeqNumInitialized {
+				totalPacketsReceived = cs.highestSeqNum - cs.baseSeqNum
+			}
+
+			stat := &livekit.AnalyticsStat{
+				TotalPackets:    uint64(totalPacketsReceived),
+				PacketLost:      uint64(cs.totalPacketsLost),
+				TotalBytes:      cs.totalBytes,
+				Delay:           uint64(cs.maxDelay),
+				Jitter:          float64(cs.maxJitter),
+				NackCount:       cs.nackCount,
+				PliCount:        cs.pliCount,
+				FirCount:        cs.firCount,
+				ConnectionScore: float32(cs.score),
+			}
+			cs.lock.Unlock()
+
+			if cs.onStatsUpdate != nil {
+				cs.onStatsUpdate(cs, stat)
+			}
+		}
+	}
 }

--- a/pkg/sfu/connectionquality/mos.go
+++ b/pkg/sfu/connectionquality/mos.go
@@ -22,16 +22,8 @@ func Score2Rating(score float64) livekit.ConnectionQuality {
 	return livekit.ConnectionQuality_POOR
 }
 
-func mosAudioEmodel(delta ConnectionStat, jitter uint32) float64 {
-
-	// find percentage of lost packets in this window
-	if delta.TotalPackets == 0 {
-		return 0.0
-	}
-
-	percentageLost := (float64(delta.PacketsLost) / float64(delta.TotalPackets)) * 100
-
-	rx := 93.2 - percentageLost
+func mosAudioEmodel(pctLoss float64, jitter uint32) float64 {
+	rx := 93.2 - pctLoss
 	ry := 0.18*rx*rx - 27.9*rx + 1126.62
 
 	// Jitter is in MicroSecs (1/1e6) units. Convert it to MilliSecs
@@ -55,27 +47,27 @@ func mosAudioEmodel(delta ConnectionStat, jitter uint32) float64 {
 	return score
 }
 
-func loss2Score(loss uint32, reducedQuality bool) float64 {
+func loss2Score(pctLoss float64, reducedQuality bool) float64 {
 	// No Loss, excellent
-	if loss == 0 && !reducedQuality {
+	if pctLoss == 0.0 && !reducedQuality {
 		return 5
 	}
 	// default when loss is minimal, but reducedQuality
 	score := 3.5
 	// loss is bad
-	if loss >= 4 {
+	if pctLoss >= 4.0 {
 		score = 2.0
-	} else if loss <= 2 && !reducedQuality {
+	} else if pctLoss <= 2.0 && !reducedQuality {
 		// loss is acceptable and at reduced quality
 		score = 4.5
 	}
 	return score
 }
 
-func AudioConnectionScore(delta ConnectionStat, jitter uint32) float64 {
-	return mosAudioEmodel(delta, jitter)
+func AudioConnectionScore(pctLoss float64, jitter uint32) float64 {
+	return mosAudioEmodel(pctLoss, jitter)
 }
 
-func VideoConnectionScore(pctLoss uint32, reducedQuality bool) float64 {
+func VideoConnectionScore(pctLoss float64, reducedQuality bool) float64 {
 	return loss2Score(pctLoss, reducedQuality)
 }

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -463,6 +463,21 @@ func (w *WebRTCReceiver) ReadRTP(buf []byte, layer uint8, sn uint16) (int, error
 	return buff.GetPacket(buf, sn)
 }
 
+func (w *WebRTCReceiver) GetTotalBytes() uint64 {
+	w.bufferMu.RLock()
+	defer w.bufferMu.RUnlock()
+
+	totalBytes := uint64(0)
+	for _, buffer := range w.buffers {
+		if buffer != nil {
+			stats := buffer.GetStats()
+			totalBytes += stats.TotalBytes
+		}
+	}
+
+	return totalBytes
+}
+
 func (w *WebRTCReceiver) forwardRTP(layer int32) {
 	w.upTrackMu.RLock()
 	tracker := w.trackers[layer]


### PR DESCRIPTION
Had repeated code and some bugs. So consolidating and fixing what I
could find. Hopefully in the process simplifying. This increases
the RTCP packet processing a bit as the packets are run through twice,
but RTCP is rare.

Still finding one issue on migration where the participant who is
not migrating drops in quality for one cycle and then recovers. But,
these changes seem to have fixed the periodic quality oscillation after
migration (as far as I could test) which is good.

The one time drop is to due a huge packet loss. Probably something when
switching to a different remote media track because of not resetting.
Will look at that in a different PR.

Hopefully, this should catch the correct upload bytes too.