### PR TITLE
Process RTX packets for TWCC

### DIFF
--- a/pkg/sfu/buffer/bucket.go
+++ b/pkg/sfu/buffer/bucket.go
@@ -33,8 +33,8 @@ func (b *Bucket) AddPacket(pkt []byte) ([]byte, error) {
 		b.init = true
 	}
 	diff := sn - b.headSN
-	if diff > (1 << 15) {
-		// out-of-order
+	if diff == 0 || diff > (1<<15) {
+		// duplicate of lsat packet or out-of-order
 		return b.set(sn, pkt)
 	}
 	b.headSN = sn


### PR DESCRIPTION
The SRTP replay detection was disabled recently.
But, they were effectively getting dropped in `sfu.bucket`.

Doing two things with RTX packets in this PR
1. Update stats - add to packet count and bytes
2. Process header extension - to process TWCC