### PR TITLE
Use buffer channel for all RTCP messages

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -287,7 +287,9 @@ func (b *Buffer) SendPLI() {
 		&rtcp.PictureLossIndication{SenderSSRC: rand.Uint32(), MediaSSRC: b.mediaSSRC},
 	}
 
-	b.feedbackCB(pli)
+	b.callbackOps <- func() {
+		b.feedbackCB(pli)
+	}
 }
 
 func (b *Buffer) SetRTT(rtt uint32) {
@@ -501,7 +503,9 @@ func (b *Buffer) doNACKs() {
 	}
 
 	if r, numSeqNumsNacked := b.buildNACKPacket(); r != nil {
-		go b.feedbackCB(r)
+		b.callbackOps <- func() {
+			b.feedbackCB(r)
+		}
 		b.stats.TotalNACKs += uint32(numSeqNumsNacked)
 	}
 }


### PR DESCRIPTION
RTCP messages are going through two channel hops now.
Maybe we don't need that anymore now that the original
problem is diagnosed. But, pushing all RTCP via
the callbackOps channel for now to make it consistent.