### PR TITLE
Need to return delta the new provisional layer takes.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -550,13 +550,13 @@ func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layers V
 
 	if requiredBitrate <= (availableChannelCapacity + alreadyAllocatedBitrate) {
 		f.provisional.layers = layers
-		return requiredBitrate
+		return requiredBitrate - alreadyAllocatedBitrate
 	}
 
 	// when pause is disallowed, pick the layer if none allocated already or something lower is available
 	if !allowPause && (f.provisional.layers == InvalidLayers || !layers.GreaterThan(f.provisional.layers)) {
 		f.provisional.layers = layers
-		return requiredBitrate
+		return requiredBitrate - alreadyAllocatedBitrate
 	}
 
 	return 0

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -362,8 +362,14 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{spatial: 0, temporal: 0}, true)
 	require.Equal(t, bitrates[0][0], usedBitrate)
 
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{spatial: 2, temporal: 3}, true)
+	require.Equal(t, bitrates[2][3]-bitrates[0][0], usedBitrate)
+
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{spatial: 0, temporal: 3}, true)
+	require.Equal(t, bitrates[0][3]-bitrates[2][3], usedBitrate)
+
 	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{spatial: 1, temporal: 2}, true)
-	require.Equal(t, bitrates[1][2], usedBitrate)
+	require.Equal(t, bitrates[1][2]-bitrates[0][3], usedBitrate)
 
 	// available not enough to reach (2, 2), allocating at (2, 2) should not succeed
 	usedBitrate = f.ProvisionalAllocate(bitrates[2][2]-bitrates[1][2]-1, VideoLayers{spatial: 2, temporal: 2}, true)


### PR DESCRIPTION
As provisional allocation runs through layers for all down tracks,
as layers go up, if a down track is able to use a higher layer,
it needs to return how much additional bandwidth it is taking up.
Not the full value as the stream allocator has already allocated
for a down track at a previously allocated layer.