### PR TITLE
Stream priority

### DIFF
--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -419,7 +419,7 @@ func (s *StreamAllocator) handleSignalSetTrackPriority(event *Event) {
 	priority, _ := event.Data.(uint8)
 	changed := track.SetPriority(priority)
 	if changed && s.state == StateDeficient {
-		// do a full allocation on a track priority to keep it simple
+		// do a full allocation on a track priority change to keep it simple
 		// LK-TODO-START
 		// When in a large room, subscriber could be adjusting priority of
 		// a lot of tracks in quick succession. That could trigger allocation burst.

--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -445,7 +445,7 @@ func (s *StreamAllocator) handleSignalEstimate(event *Event) {
 	//
 
 	// if there are no video tracks, ignore any straggler REMB
-	if len(s.getSorted()) == 0 {
+	if len(s.videoTracks) == 0 {
 		return
 	}
 


### PR DESCRIPTION
- Priority range (1: Lowest - 255: Highest)
- Default screen share priority: 255
- Default video (camera) priority: 1
- Consolidate functions for sorting and sort only when needed. Eliminate maintaining sorted list. That code is cumbersome and error prone. If the number of tracks are so high that sorting at more opportune time makes sense, we can revisit keeping sorted lists.