### PR TITLE
Fix no-video with adaptive streaming

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -179,8 +179,8 @@ func (t *MediaTrackReceiver) AddOnClose(f func()) {
 
 // AddSubscriber subscribes sub to current mediaTrack
 func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 
 	if t.receiver == nil {
 		// cannot add, no receiver

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -58,6 +58,7 @@ func NewMediaTrackSubscriptions(params MediaTrackSubscriptionsParams) *MediaTrac
 		subscribedTracks:         make(map[livekit.ParticipantID]types.SubscribedTrack),
 		maxSubscriberQuality:     make(map[livekit.ParticipantID]livekit.VideoQuality),
 		maxSubscriberNodeQuality: make(map[livekit.NodeID]livekit.VideoQuality),
+		maxSubscribedQuality:     livekit.VideoQuality_LOW,
 	}
 
 	return t
@@ -260,6 +261,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, code
 	// initialize to default layer
 	t.maxSubscriberQuality[sub.ID()] = livekit.VideoQuality_HIGH
 	t.maxQualityLock.Unlock()
+
 	t.params.Telemetry.TrackSubscribed(context.Background(), subscriberID, t.params.MediaTrack.ToProto())
 	return downTrack, nil
 }
@@ -420,12 +422,6 @@ func (t *MediaTrackSubscriptions) notifySubscriberMaxQuality(subscriberID liveki
 
 		delete(t.maxSubscriberQuality, subscriberID)
 	} else {
-		maxQuality, ok := t.maxSubscriberQuality[subscriberID]
-		if ok && maxQuality == quality {
-			t.maxQualityLock.Unlock()
-			return
-		}
-
 		t.maxSubscriberQuality[subscriberID] = quality
 	}
 	t.maxQualityLock.Unlock()
@@ -448,12 +444,6 @@ func (t *MediaTrackSubscriptions) NotifySubscriberNodeMaxQuality(nodeID livekit.
 
 		delete(t.maxSubscriberNodeQuality, nodeID)
 	} else {
-		maxQuality, ok := t.maxSubscriberNodeQuality[nodeID]
-		if ok && maxQuality == quality {
-			t.maxQualityLock.Unlock()
-			return
-		}
-
 		t.maxSubscriberNodeQuality[nodeID] = quality
 	}
 	t.maxQualityLock.Unlock()

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -633,11 +633,6 @@ func (d *DownTrack) OnRttUpdate(fn func(dt *DownTrack, rtt uint32)) {
 
 func (d *DownTrack) OnMaxLayerChanged(fn func(dt *DownTrack, layer int32)) {
 	d.onMaxLayerChanged = fn
-
-	// have to send this immediately to set initial values
-	if fn != nil && d.kind == webrtc.RTPCodecTypeVideo {
-		go fn(d, d.forwarder.MaxLayers().spatial)
-	}
 }
 
 func (d *DownTrack) IsDeficient() bool {


### PR DESCRIPTION
With a recent change to initialize max quality for subscriber
synchronously, a subsequent update at the same quality was
getting ignored. So, there was no message back to publisher
to start up video layers. Reproducible every time the subscriber
joined after all the layers of publishers was turned off.

While not pretty, for now, disable the check for quality match
on subscriber update. That disabling itself is fine as there is
another check for consolidated quality match before sending
a message to the publisher, but in general this area has shown
some shakiness and needs some work.