### PR TITLE
Staticcheck

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type CongestionControlProbeMode string
 
 const (
 	CongestionControlProbeModePadding CongestionControlProbeMode = "padding"
-	CongestionControlProbeModeMedia                              = "media"
+	CongestionControlProbeModeMedia   CongestionControlProbeMode = "media"
 )
 
 type Config struct {

--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -457,7 +457,7 @@ func (r *RedisRouter) handleRTCMessage(rm *livekit.RTCNodeMessage) error {
 		}
 
 	case *livekit.RTCNodeMessage_KeepAlive:
-		if time.Now().Sub(time.Unix(rm.SenderTime, 0)) > statsUpdateInterval {
+		if time.Since(time.Unix(rm.SenderTime, 0)) > statsUpdateInterval {
 			logger.Infow("keep alive too old, skipping", "senderTime", rm.SenderTime)
 			break
 		}

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -29,8 +29,6 @@ type MediaTrack struct {
 	audioLevelMu sync.RWMutex
 	audioLevel   *AudioLevel
 
-	done chan struct{}
-
 	*MediaTrackReceiver
 
 	lock sync.RWMutex

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -81,9 +81,6 @@ type ParticipantImpl struct {
 	// when first connected
 	connectedAt time.Time
 
-	// JSON encoded metadata to pass to clients
-	metadata string
-
 	rtcpCh chan []rtcp.Packet
 
 	// hold reference for MediaTrack

--- a/pkg/service/redisstore.go
+++ b/pkg/service/redisstore.go
@@ -139,7 +139,7 @@ func (s *RedisStore) LockRoom(_ context.Context, name livekit.RoomName, duration
 		}
 
 		// stop waiting past lock duration
-		if time.Now().Sub(startTime) > duration {
+		if time.Since(startTime) > duration {
 			break
 		}
 
@@ -282,7 +282,7 @@ func (s *RedisStore) ListEgress(_ context.Context, roomID livekit.RoomID) ([]*li
 			return nil, err
 		}
 
-		data, err := s.rc.HMGet(s.ctx, EgressKey, ids...).Result()
+		data, _ := s.rc.HMGet(s.ctx, EgressKey, ids...).Result()
 		for _, d := range data {
 			if d == nil {
 				continue

--- a/pkg/service/roomallocator_test.go
+++ b/pkg/service/roomallocator_test.go
@@ -40,7 +40,7 @@ func TestCreateRoom(t *testing.T) {
 		node.Stats.NumTracksIn = 100
 		node.Stats.NumTracksOut = 100
 
-		ra, conf := newTestRoomAllocator(t, conf, node)
+		ra, _ := newTestRoomAllocator(t, conf, node)
 
 		_, err = ra.CreateRoom(context.Background(), &livekit.CreateRoomRequest{Name: "low-limit-room"})
 		require.ErrorIs(t, err, routing.ErrNodeLimitReached)
@@ -56,7 +56,7 @@ func TestCreateRoom(t *testing.T) {
 		node.Stats.BytesInPerSec = 1000
 		node.Stats.BytesOutPerSec = 1000
 
-		ra, conf := newTestRoomAllocator(t, conf, node)
+		ra, _ := newTestRoomAllocator(t, conf, node)
 
 		_, err = ra.CreateRoom(context.Background(), &livekit.CreateRoomRequest{Name: "low-limit-room"})
 		require.ErrorIs(t, err, routing.ErrNodeLimitReached)

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -381,7 +381,7 @@ func (r *RoomManager) rtcSessionWorker(room *rtc.Room, participant types.LocalPa
 				return
 			}
 
-			if time.Now().Sub(lastTokenUpdate) > tokenRefreshInterval {
+			if time.Since(lastTokenUpdate) > tokenRefreshInterval {
 				pLogger.Debugw("refreshing client token after interval")
 				// refresh token with the first API Key/secret pair
 				if err := r.refreshToken(participant); err != nil {

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -96,7 +96,7 @@ func (s *RTCService) validate(r *http.Request) (livekit.RoomName, routing.Partic
 	// this is new connection for existing participant -  with publish only permissions
 	if publishParam != "" {
 		// Make sure grant has CanPublish set,
-		if claims.Video.CanPublish != nil && *claims.Video.CanPublish == false {
+		if claims.Video.CanPublish != nil && !*claims.Video.CanPublish {
 			return "", routing.ParticipantInit{}, http.StatusUnauthorized, rtc.ErrPermissionDenied
 		}
 		// Make sure by default subscribe is off

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -279,7 +279,7 @@ func (s *LivekitServer) healthCheck(w http.ResponseWriter, _ *http.Request) {
 	if s.Node().Stats != nil {
 		updatedAt = time.Unix(s.Node().Stats.UpdatedAt, 0)
 	}
-	if time.Now().Sub(updatedAt) > 4*time.Second {
+	if time.Since(updatedAt) > 4*time.Second {
 		w.WriteHeader(http.StatusNotAcceptable)
 		_, _ = w.Write([]byte(fmt.Sprintf("Not Ready\nNode Updated At %s", updatedAt)))
 		return

--- a/pkg/sfu/buffer/buffer_test.go
+++ b/pkg/sfu/buffer/buffer_test.go
@@ -147,7 +147,6 @@ func TestNack(t *testing.T) {
 func TestNewBuffer(t *testing.T) {
 	type args struct {
 		options Options
-		ssrc    uint32
 	}
 	tests := []struct {
 		name string

--- a/pkg/sfu/buffer/nack.go
+++ b/pkg/sfu/buffer/nack.go
@@ -136,7 +136,7 @@ func (n *nack) getNack(now time.Time, rtt uint32) (shouldSend bool, shouldRemove
 	var requiredInterval time.Duration
 	if n.tries > 0 {
 		// exponentially backoff retries, but cap maximum spacing between retries
-		requiredInterval := maxInterval
+		requiredInterval = maxInterval
 		backoffInterval := time.Duration(float64(rtt)*math.Pow(backoffFactor, float64(n.tries-1))) * time.Millisecond
 		if backoffInterval < requiredInterval {
 			requiredInterval = backoffInterval

--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -120,7 +120,7 @@ func (cs *ConnectionStats) updateScore() float32 {
 	maxRTT := uint32(0)
 	maxJitter := uint32(0)
 	for _, qw := range cs.qualityWindows {
-		expectedPacketsInInterval += qw.endSeqNum - qw.endSeqNum + 1
+		expectedPacketsInInterval += qw.endSeqNum - qw.startSeqNum + 1
 		lostPacketsInInterval += qw.endPacketsLost - qw.startPacketsLost
 		if qw.maxRTT > maxRTT {
 			maxRTT = qw.maxRTT

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -984,7 +984,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		SSRC:           0x12345678,
 		PayloadSize:    20,
 	}
-	extPkt, err := testutils.GetTestExtPacket(params)
+	extPkt, _ := testutils.GetTestExtPacket(params)
 
 	// should lock onto the first packet
 	expectedTP := TranslationParams{
@@ -1015,7 +1015,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		SSRC:           0x12345678,
 		PayloadSize:    20,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		shouldDrop:         true,
@@ -1032,7 +1032,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		Timestamp:      0xabcdef,
 		SSRC:           0x12345678,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		shouldDrop: true,
@@ -1049,7 +1049,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		SSRC:           0x12345678,
 		PayloadSize:    20,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
@@ -1069,7 +1069,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		Timestamp:      0xabcdef,
 		SSRC:           0x12345678,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
@@ -1090,7 +1090,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		SSRC:           0x12345678,
 		PayloadSize:    20,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
@@ -1111,7 +1111,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 		SSRC:           0x87654321,
 		PayloadSize:    20,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
@@ -1387,7 +1387,7 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		Timestamp:      0xabcdef,
 		SSRC:           0x12345678,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
@@ -1407,7 +1407,7 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		Timestamp:      0xabcdef,
 		SSRC:           0x12345678,
 	}
-	extPkt, err = testutils.GetTestExtPacket(params)
+	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{

--- a/pkg/sfu/twcc/twcc.go
+++ b/pkg/sfu/twcc/twcc.go
@@ -32,15 +32,14 @@ type rtpExtInfo struct {
 type Responder struct {
 	sync.Mutex
 
-	extInfo     []rtpExtInfo
-	lastReport  int64
-	cycles      uint32
-	lastExtSN   uint32
-	pktCtn      uint8
-	lastSn      uint16
-	lastExtInfo uint16
-	mSSRC       uint32
-	sSSRC       uint32
+	extInfo    []rtpExtInfo
+	lastReport int64
+	cycles     uint32
+	lastExtSN  uint32
+	pktCtn     uint8
+	lastSn     uint16
+	mSSRC      uint32
+	sSSRC      uint32
 
 	len      uint16
 	deltaLen uint16

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -68,7 +68,7 @@ func RoomStarted() {
 
 func RoomEnded(startedAt time.Time) {
 	if !startedAt.IsZero() {
-		promRoomDuration.Observe(float64(time.Now().Sub(startedAt)) / float64(time.Second))
+		promRoomDuration.Observe(float64(time.Since(startedAt)) / float64(time.Second))
 	}
 	promRoomTotal.Sub(1)
 	atomic.AddInt32(&atomicRoomTotal, -1)

--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -287,8 +287,6 @@ func (stats *Stats) coalesce() {
 
 	// update currentStats
 	stats.curStats = &curStats
-
-	return
 }
 
 // find delta between  curStats and prevStats and prepare proto payload

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -717,7 +717,7 @@ func (c *RTCClient) processTrack(track *webrtc.TrackRemote) {
 		c.bytesReceived[pId] += uint64(pkt.MarshalSize())
 		c.lock.Unlock()
 		numBytes += pkt.MarshalSize()
-		if time.Now().Sub(lastUpdate) > 30*time.Second {
+		if time.Since(lastUpdate) > 30*time.Second {
 			logger.Infow("consumed from participant",
 				"track", trackId, "pID", pId,
 				"size", numBytes)

--- a/test/client/trackwriter.go
+++ b/test/client/trackwriter.go
@@ -96,7 +96,7 @@ func (w *TrackWriter) writeNull() {
 				w.track.WriteSample(sample)
 			}
 		case <-w.ctx.Done():
-			break
+			return
 		}
 	}
 }

--- a/test/multinode_test.go
+++ b/test/multinode_test.go
@@ -185,7 +185,7 @@ func TestMultiNodeRefreshToken(t *testing.T) {
 		grants, err := verifier.Verify(testApiSecret)
 		require.NoError(t, err)
 
-		if "metadata" != grants.Metadata {
+		if grants.Metadata != "metadata" {
 			return "metadata did not match"
 		}
 		if *grants.Video.CanPublish {


### PR DESCRIPTION
Using `go get -u honnef.co/go/tools/cmd/staticcheck`
Unearthed a couple of real bugs

It still reports the following
```
pkg/logger/logger.go:15:2: var logConfig is unused (U1000)
pkg/service/auth.go:78:44: should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
pkg/service/roomservice_test.go:26:50: should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
pkg/service/roomservice_test.go:39:50: should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
pkg/service/server.go:233:3: should use a simple channel send/receive instead of select with a single case (S1000)
pkg/sfu/atomic.go:18:6: type atomicUint8 is unused (U1000)
pkg/sfu/atomic.go:20:23: func (*atomicUint8).set is unused (U1000)
pkg/sfu/atomic.go:24:23: func (*atomicUint8).get is unused (U1000)
pkg/sfu/atomic.go:30:24: func (*atomicUint32).set is unused (U1000)
```