### PR TITLE
Callback queue for a couple of modules

### DIFF
--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -222,7 +222,7 @@ func (s *StreamAllocator) AddTrack(downTrack *DownTrack, params AddTrackParams) 
 		downTrack.OnAvailableLayersChanged(s.onAvailableLayersChanged)
 		downTrack.OnSubscriptionChanged(s.onSubscriptionChanged)
 		downTrack.OnSubscribedLayersChanged(s.onSubscribedLayersChanged)
-		downTrack.OnPacketSent(s.onPacketSent)
+		downTrack.OnPacketSentUnsafe(s.onPacketSent)
 	}
 }
 


### PR DESCRIPTION
Doing this bits at a time to see how it goes. Did a couple of modules.

Also, for callbacks which are very frequent like `onPacketSent` in `sfu.DownTrack`, not putting it into the queue. Marking it as `Unsafe` as a matter of convention to show that it is not going through a queue and modules registering that callback should handle with care. Let me know what you think.

Also thinking if I should add a queue size argument to `NewOpsQueue`. Currently, it uses 50 by default.