### PR TITLE
Disable default node limits

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/mitchellh/go-homedir"
@@ -225,7 +224,7 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 		},
 		NodeSelector: NodeSelectorConfig{
 			Kind:         "random",
-			SysloadLimit: 0.7,
+			SysloadLimit: 0.9,
 		},
 		Keys: map[string]string{},
 	}
@@ -264,17 +263,6 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if conf.Limit.NumTracks == 0 {
-		conf.Limit.NumTracks = defaultLimitNumTracksPerCPU * int32(runtime.NumCPU())
-		if conf.Limit.NumTracks > defaultLimitMaxNumTracks {
-			conf.Limit.NumTracks = defaultLimitMaxNumTracks
-		}
-	}
-
-	if conf.Limit.BytesPerSec == 0 {
-		conf.Limit.BytesPerSec = defaultLimitBytesPerSec
 	}
 
 	if conf.LogLevel != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,12 +12,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	defaultLimitNumTracksPerCPU int32   = 400
-	defaultLimitMaxNumTracks    int32   = 8000
-	defaultLimitBytesPerSec     float32 = 1_000_000_000 // just under 10 Gbps
-)
-
 var DefaultStunServers = []string{
 	"stun.l.google.com:19302",
 	"stun1.l.google.com:19302",


### PR DESCRIPTION
Users reported. having issues while their node had little load. I've seen this error as well during load testing (when the load is still well within the limits). Disabling by default as it's an advanced setting.