### PR TITLE
Keep track of pending subscription close.

### DIFF
--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -9,8 +9,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"os"
-
 	"github.com/go-redis/redis/v8"
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/routing"
@@ -21,6 +19,7 @@ import (
 	"github.com/livekit/protocol/webhook"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
+	"os"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
Introduce a pending close map and fire onNoSubscribers only
when there are not subscribed and no pending close.

There are a couple of paths for down track close
- RemoveSubscriber
- RemoveAllSubscriber
We remove the subscriber from `subscribedTracks` in these.
This is because `AddSubscriber` checks for existing subscription.
If there is a remove followed by an add, the add should not think
there is an existing susbcription if there is a delay in down track
close callback.

But, down track close is also called directly from places like
participant close. So, have to clean up both subscribedTrack
and pendingClose when the down track close fires.

Call onNoSubscribers only when both are empty. This will allow
relay up track to stop properly when all susbcribers have left.