### PR TITLE
fix timing issue for clear receiver

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -172,6 +172,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 		wr.OnCloseHandler(func() {
 			t.RemoveAllSubscribers()
 			t.MediaTrackReceiver.Close()
+			t.MediaTrackReceiver.ClearReceiver()
 			t.params.Telemetry.TrackUnpublished(context.Background(), t.PublisherID(), t.ToProto(), uint32(track.SSRC()))
 		})
 		wr.OnStatsUpdate(func(_ *sfu.WebRTCReceiver, stat *livekit.AnalyticsStat) {

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -108,7 +108,6 @@ func (t *MediaTrackReceiver) OnVideoLayerUpdate(f func(layers []*livekit.VideoLa
 
 func (t *MediaTrackReceiver) Close() {
 	t.lock.Lock()
-	t.receiver = nil
 	onclose := t.onClose
 	t.lock.Unlock()
 


### PR DESCRIPTION
fix timing issue for MeidiaReceiver.Close and clear receiver. we can fix it to regress to synchronize DownTrack.onclose callback, but unify async callback queue makes more sense to avoid potential deadlock.