### PR TITLE
fix potential nil rtcp packets cause rtcpSendWorker exit

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -562,9 +562,11 @@ func (b *Buffer) doReports(arrivalTime int64) {
 
 	// RTCP reports
 	pkts := b.getRTCP()
-	b.callbacksQueue.Enqueue(func() {
-		b.feedbackCB(pkts)
-	})
+	if pkts != nil {
+		b.callbacksQueue.Enqueue(func() {
+			b.feedbackCB(pkts)
+		})
+	}
 }
 
 func (b *Buffer) buildNACKPacket() ([]rtcp.Packet, int) {

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -377,7 +377,7 @@ func (w *WebRTCReceiver) DeleteDownTrack(peerID livekit.ParticipantID) {
 }
 
 func (w *WebRTCReceiver) sendRTCP(packets []rtcp.Packet) {
-	if w.closed.Load() {
+	if packets == nil || w.closed.Load() {
 		return
 	}
 


### PR DESCRIPTION
in case of packet lost or out of order in a report cycle, the buidlReceptionReport will return a nil rtcppacket that send to rtcpCh, cause rtcpSendWorker exit, then sendRtcp will report "rtcp channel full"