### PR TITLE
Locks around data track

### DIFF
--- a/pkg/rtc/datatrack.go
+++ b/pkg/rtc/datatrack.go
@@ -69,6 +69,10 @@ func (t *DataTrack) OnDataPacket(f func(*livekit.DataPacket)) {
 	t.lock.Unlock()
 }
 
+func (t *DataTrack) ID() livekit.TrackID {
+	return t.trackID
+}
+
 func (t *DataTrack) TrackID() livekit.TrackID {
 	return t.trackID
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -315,9 +315,11 @@ func (p *ParticipantImpl) ToProto(mediaTrackOnly bool) *livekit.ParticipantInfo 
 		info.Metadata = p.params.Grants.Metadata
 	}
 
+	p.lock.RLock()
 	if !mediaTrackOnly && p.dataTrack != nil {
 		info.Tracks = append(info.Tracks, p.dataTrack.ToProto())
 	}
+	p.lock.RUnlock()
 
 	return info
 }
@@ -499,9 +501,16 @@ func (p *ParticipantImpl) Close(sendLeave bool) error {
 		})
 	}
 
-	if p.dataTrack != nil {
-		p.dataTrack.Close()
+	var dt *DataTrack
+	p.lock.Lock()
+	dt = p.dataTrack
+	p.dataTrack = nil
+	p.lock.Unlock()
+
+	if dt != nil {
+		dt.Close()
 	}
+
 	p.UpTrackManager.Close()
 
 	p.pendingTracksLock.Lock()
@@ -1085,15 +1094,25 @@ func (p *ParticipantImpl) OnDataTrackPublished(f func(types.LocalParticipant, ty
 }
 
 func (p *ParticipantImpl) onDataChannel(dc *webrtc.DataChannel) {
+	p.lock.Lock()
+	created := p.onDataChannelLocked(dc)
+	dt := p.dataTrack
+	p.lock.Unlock()
+
+	if created && p.onDataTrackPublished != nil && dt != nil {
+		p.onDataTrackPublished(p, dt)
+	}
+}
+
+func (p *ParticipantImpl) onDataChannelLocked(dc *webrtc.DataChannel) (created bool) {
 	if p.State() == livekit.ParticipantInfo_DISCONNECTED {
 		return
 	}
 	if p.dataTrack == nil {
 		p.dataTrack = NewDataTrack(livekit.TrackID("DT_"+p.params.SID), p.params.SID, p.params.Logger)
-		if p.onDataTrackPublished != nil {
-			p.onDataTrackPublished(p, p.dataTrack)
-		}
+		created = true
 	}
+
 	label := dc.Label()
 	switch label {
 	case reliableDataChannel:
@@ -1115,6 +1134,8 @@ func (p *ParticipantImpl) onDataChannel(dc *webrtc.DataChannel) {
 	default:
 		p.params.Logger.Warnw("unsupported datachannel added", nil, "label", dc.Label())
 	}
+
+	return
 }
 
 func (p *ParticipantImpl) handlePrimaryStateChange(state webrtc.PeerConnectionState) {
@@ -1618,12 +1639,15 @@ func (p *ParticipantImpl) DebugInfo() map[string]interface{} {
 }
 
 func (p *ParticipantImpl) GetDataTrack() types.DataTrack {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
 	return p.dataTrack
 }
 
 func (p *ParticipantImpl) handlePendingDataChannels() {
 	p.lock.Lock()
-	defer p.lock.Unlock()
+	created := false
 	ordered := true
 	negotiated := true
 	for _, ci := range p.pendingDataChannels {
@@ -1651,10 +1675,17 @@ func (p *ParticipantImpl) handlePendingDataChannels() {
 		if err != nil {
 			p.params.Logger.Errorw("create migrated data channel failed", err, "label", ci.Label)
 		} else if dc != nil {
-			p.onDataChannel(dc)
+			created = created || p.onDataChannelLocked(dc)
 		}
 	}
 	p.pendingDataChannels = nil
+
+	dt := p.dataTrack
+	p.lock.Unlock()
+
+	if created && p.onDataTrackPublished != nil && dt != nil {
+		p.onDataTrackPublished(p, dt)
+	}
 }
 
 func (p *ParticipantImpl) GetSubscribedTracks() []types.SubscribedTrack {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1642,7 +1642,11 @@ func (p *ParticipantImpl) GetDataTrack() types.DataTrack {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return p.dataTrack
+	if dt := p.dataTrack; dt != nil {
+		return dt
+	}
+
+	return nil
 }
 
 func (p *ParticipantImpl) handlePendingDataChannels() {
@@ -1675,7 +1679,8 @@ func (p *ParticipantImpl) handlePendingDataChannels() {
 		if err != nil {
 			p.params.Logger.Errorw("create migrated data channel failed", err, "label", ci.Label)
 		} else if dc != nil {
-			created = created || p.onDataChannelLocked(dc)
+			creating := p.onDataChannelLocked(dc)
+			created = created || creating
 		}
 	}
 	p.pendingDataChannels = nil

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -221,9 +221,9 @@ func (r *Room) Join(participant types.LocalParticipant, opts *ParticipantOptions
 	})
 	participant.OnTrackUpdated(r.onTrackUpdated)
 	participant.OnMetadataUpdate(r.onParticipantMetadataUpdate)
-	participant.OnDataTrackPublished(func(lp types.LocalParticipant, dt types.DataTrack) {
+	participant.OnDataTrackPublished(func(p types.LocalParticipant, dt types.DataTrack) {
 		dt.OnDataPacket(func(dp *livekit.DataPacket) {
-			r.onDataPacket(lp, dp)
+			r.onDataPacket(p, dp)
 		})
 	})
 	r.Logger.Infow("new participant joined",

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -244,6 +244,7 @@ type SubscribedTrack interface {
 // DataTrack is the interface representing a data track published to the room
 //counterfeiter:generate . DataTrack
 type DataTrack interface {
+	ID() livekit.TrackID
 	TrackID() livekit.TrackID
 	Receiver() sfu.TrackReceiver
 	AddOnClose(func())

--- a/pkg/rtc/types/typesfakes/fake_data_track.go
+++ b/pkg/rtc/types/typesfakes/fake_data_track.go
@@ -15,6 +15,16 @@ type FakeDataTrack struct {
 	addOnCloseArgsForCall []struct {
 		arg1 func()
 	}
+	IDStub        func() livekit.TrackID
+	iDMutex       sync.RWMutex
+	iDArgsForCall []struct {
+	}
+	iDReturns struct {
+		result1 livekit.TrackID
+	}
+	iDReturnsOnCall map[int]struct {
+		result1 livekit.TrackID
+	}
 	KindStub        func() livekit.TrackType
 	kindMutex       sync.RWMutex
 	kindArgsForCall []struct {
@@ -84,6 +94,59 @@ func (fake *FakeDataTrack) AddOnCloseArgsForCall(i int) func() {
 	defer fake.addOnCloseMutex.RUnlock()
 	argsForCall := fake.addOnCloseArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeDataTrack) ID() livekit.TrackID {
+	fake.iDMutex.Lock()
+	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
+	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
+	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
+	fake.recordInvocation("ID", []interface{}{})
+	fake.iDMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeDataTrack) IDCallCount() int {
+	fake.iDMutex.RLock()
+	defer fake.iDMutex.RUnlock()
+	return len(fake.iDArgsForCall)
+}
+
+func (fake *FakeDataTrack) IDCalls(stub func() livekit.TrackID) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = stub
+}
+
+func (fake *FakeDataTrack) IDReturns(result1 livekit.TrackID) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = nil
+	fake.iDReturns = struct {
+		result1 livekit.TrackID
+	}{result1}
+}
+
+func (fake *FakeDataTrack) IDReturnsOnCall(i int, result1 livekit.TrackID) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = nil
+	if fake.iDReturnsOnCall == nil {
+		fake.iDReturnsOnCall = make(map[int]struct {
+			result1 livekit.TrackID
+		})
+	}
+	fake.iDReturnsOnCall[i] = struct {
+		result1 livekit.TrackID
+	}{result1}
 }
 
 func (fake *FakeDataTrack) Kind() livekit.TrackType {
@@ -282,6 +345,8 @@ func (fake *FakeDataTrack) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.addOnCloseMutex.RLock()
 	defer fake.addOnCloseMutex.RUnlock()
+	fake.iDMutex.RLock()
+	defer fake.iDMutex.RUnlock()
 	fake.kindMutex.RLock()
 	defer fake.kindMutex.RUnlock()
 	fake.onDataPacketMutex.RLock()


### PR DESCRIPTION
@cnderrauber Setting up this PR to get your :eyes: I am putting locks and making sure the callback happens outside the lock. I also added an ID method to data track interface so that there is no need to cast. But, data track does not work after migration with these changes. Don't know what is causing that. But, wanted to get your thoughts.