### PR TITLE
set participant to active after subscriber data channel opened

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -659,7 +659,10 @@ func (r *Room) onDataPacket(source types.LocalParticipant, dp *livekit.DataPacke
 				continue
 			}
 		}
-		_ = op.SendDataPacket(dp)
+		err := op.SendDataPacket(dp)
+		if err != nil {
+			r.Logger.Infow("send datapacket error", "error", err, "participant", op.Identity())
+		}
 	}
 }
 


### PR DESCRIPTION
fix https://github.com/livekit/server-sdk-go/issues/49

when we set participant to active, its subscriber data channel might not open yet, if other participant send data to it at same time, data might lost