### PR TITLE
fix keyFrameRequestGeneration not exit after close

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -245,7 +245,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 // because a track has been stopped.
 func (d *DownTrack) Unbind(_ webrtc.TrackLocalContext) error {
 	d.bound.Store(false)
-	d.stopKeyFrameRequester()
 	return nil
 }
 


### PR DESCRIPTION
see log "cloud-media	sfu/downtrack.go:712	stream: allocation" after close downtrack, keyframeRequest started after downtrack closed.