### PR TITLE
Reduce chatty logs

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1216,8 +1216,22 @@ func (p *ParticipantImpl) onSubscribedMaxQualityChange(trackID livekit.TrackID, 
 		SubscribedQualities: subscribedQualities,
 	}
 
-	p.params.Telemetry.TrackMaxSubscribedVideoQuality(context.Background(), p.ID(), &livekit.TrackInfo{Sid: string(trackID), Type: livekit.TrackType_VIDEO}, maxSubscribedQuality)
+	p.params.Telemetry.TrackMaxSubscribedVideoQuality(
+		context.Background(),
+		p.ID(),
+		&livekit.TrackInfo{
+			Sid:  string(trackID),
+			Type: livekit.TrackType_VIDEO,
+		},
+		maxSubscribedQuality,
+	)
 
+	p.params.Logger.Debugw(
+		"sending max subscribed quality",
+		"trackID", trackID,
+		"qualities", subscribedQualities,
+		"max", maxSubscribedQuality,
+	)
 	return p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_SubscribedQualityUpdate{
 			SubscribedQualityUpdate: subscribedQualityUpdate,

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -461,7 +461,6 @@ func (b *Buffer) getExtPacket(rawPacket []byte, rtpPacket *rtp.Packet, arrivalTi
 		ep.KeyFrame = IsAV1Keyframe(rtpPacket.Payload)
 	}
 	if ep.KeyFrame {
-		b.logger.Debugw("key frame received")
 		if b.rtpStats != nil {
 			b.rtpStats.UpdateKeyFrame(1)
 		}

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -410,6 +410,8 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 			if locked {
 				d.stopKeyFrameRequester()
 			}
+
+			d.logger.Debugw("forwarding key frame", "layer", layer)
 		}
 
 		d.rtpStats.Update(hdr, len(payload), 0, time.Now().UnixNano())

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -934,6 +934,7 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 		if pliOnce {
 			targetLayers := d.forwarder.TargetLayers()
 			if targetLayers != InvalidLayers {
+				d.logger.Debugw("sending PLI RTCP", "layer", targetLayers.spatial)
 				d.receiver.SendPLI(targetLayers.spatial)
 				d.isNACKThrottled.Store(true)
 				d.rtpStats.UpdatePliTime()


### PR DESCRIPTION
- RTPStats debiug logging is not necessary any more. It is
stable now. There are large jumps happening still. But, they
happen due to publisher jumps or relay re-attach delay.
- Key frame received is chatty. We have logs for when PLI
is sent (adding one when RTCP requests one) and also when layer
lock happens. One case where there is no logging is when a key
frame is requested via RTCP from subscriber. Adding a log for
that when a key frame is forwarded.