### PR TITLE
Prevent negative timestamp diff

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1175,6 +1175,9 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 			// Compute how much time passed between the old RTP extPkt
 			// and the current packet, and fix timestamp on source change
 			tDiffMs := (extPkt.Arrival - f.lTSCalc) / 1e6
+			if tDiffMs < 0 {
+				tDiffMs = 0
+			}
 			td := uint32(tDiffMs * int64(f.codec.ClockRate) / 1000)
 			if td == 0 {
 				td = 1


### PR DESCRIPTION
Found another reason for potential stalling on layer switch up.

When switching up, it is possible that the key frame of the packet
at higher layer arrives very close to a packet in the currently
forwarded layer.

An inversion happens when higher layer packet arrives earlier
(as timestamped at receicver), but gets scheduled for forwarding
later (as seen by forwarder).

Because of the order of processing goroutines,
it is possible to have negative diff when trying to adjust
RTP timestamps for layer switch. A negative diff results in
large jump in RTP timestamp. Client stalls, sends PLI three seconds
later (3 seconds is a Chrome thing, not sure about others), waits
for another key frame and starts again. In the mean time, the
video is frozen.