### PR TITLE
Prevent stats update if the deltas are empty

### DIFF
--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -26,7 +26,7 @@ const (
 	// expire participant mappings after a day
 	participantMappingTTL = 24 * time.Hour
 	statsUpdateInterval   = 2 * time.Second
-	statsMaxDelaySeconds  = 10
+	statsMaxDelaySeconds  = 30
 )
 
 // RedisRouter uses Redis pub/sub to route signaling messages across different nodes

--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -483,7 +483,9 @@ func (r *RedisRouter) handleRTCMessage(rm *livekit.RTCNodeMessage) error {
 		if err != nil {
 			logger.Errorw("could not update node stats", err)
 		} else {
-			r.currentNode.Stats = updated
+			if updated != nil {
+				r.currentNode.Stats = updated
+			}
 		}
 		r.statsMu.Unlock()
 

--- a/pkg/routing/selector/utils.go
+++ b/pkg/routing/selector/utils.go
@@ -15,6 +15,11 @@ const AvailableSeconds = 5
 
 // checks if a node has been updated recently to be considered for selection
 func IsAvailable(node *livekit.Node) bool {
+	if node.Stats == nil {
+		// available till stats are available
+		return true
+	}
+
 	delta := time.Now().Unix() - node.Stats.UpdatedAt
 	return int(delta) < AvailableSeconds
 }
@@ -82,12 +87,12 @@ func SelectSortedNode(nodes []*livekit.Node, sortBy string) (*livekit.Node, erro
 		return nodes[0], nil
 	case "tracks":
 		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].Stats.NumTracksIn + nodes[i].Stats.NumTracksOut < nodes[j].Stats.NumTracksIn + nodes[j].Stats.NumTracksOut
+			return nodes[i].Stats.NumTracksIn+nodes[i].Stats.NumTracksOut < nodes[j].Stats.NumTracksIn+nodes[j].Stats.NumTracksOut
 		})
 		return nodes[0], nil
 	case "bytespersec":
 		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].Stats.BytesInPerSec + nodes[i].Stats.BytesOutPerSec < nodes[j].Stats.BytesInPerSec + nodes[j].Stats.BytesOutPerSec
+			return nodes[i].Stats.BytesInPerSec+nodes[i].Stats.BytesOutPerSec < nodes[j].Stats.BytesInPerSec+nodes[j].Stats.BytesOutPerSec
 		})
 		return nodes[0], nil
 	default:

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	livekitNamespace    string = "livekit"
-	forceUpdateInterval        = 10
+	forceUpdateInterval        = 15
 )
 
 var (

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	livekitNamespace    string = "livekit"
-	forceUpdateInterval        = 15
+	forceUpdateInterval int64  = 15
 )
 
 var (

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -10,7 +10,10 @@ import (
 	"github.com/livekit/protocol/utils"
 )
 
-const livekitNamespace string = "livekit"
+const (
+	livekitNamespace    string = "livekit"
+	forceUpdateInterval        = 10
+)
 
 var (
 	MessageCounter          *prometheus.CounterVec
@@ -65,6 +68,15 @@ func GetUpdatedNodeStats(prev *livekit.NodeStats) (*livekit.NodeStats, error) {
 	packetsInNow := packetsIn.Load()
 	packetsOutNow := packetsOut.Load()
 	nackTotalNow := nackTotal.Load()
+
+	if bytesInNow == prev.BytesIn &&
+		bytesOutNow == prev.BytesOut &&
+		packetsInNow == prev.PacketsIn &&
+		packetsOutNow == prev.PacketsOut &&
+		nackTotalNow == prev.NackTotal &&
+		elapsed < forceUpdateInterval {
+		return nil, nil
+	}
 
 	return &livekit.NodeStats{
 		StartedAt:        prev.StartedAt,


### PR DESCRIPTION
An attempt at addressing #617 . This does not increase update frequency, but prevents the deltas from being 0 till stats are available.

(Have verified via logging that the updated stats have change in values. But, still seeing zeros in `list-nodes`. Actually, I have never seen non-zeros there, my redis based set up for local dev is missing something)