### PR TITLE
Improve docker connectivity by using srflx candidates

### DIFF
--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -207,7 +207,7 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 	}
 
 	// use STUN servers for server to support NAT
-	// when deployed in production, we expect UseExternalIP to be used, and ports being accessible
+	// when deployed in production, we expect UseExternalIP to be used, and ports accessible
 	if !conf.RTC.UseExternalIP {
 		if len(conf.RTC.STUNServers) > 0 {
 			c.ICEServers = []webrtc.ICEServer{iceServerForStunServers(conf.RTC.STUNServers)}


### PR DESCRIPTION
When deployed via Docker and without using host networking, we'll be
assigned an IP behind NAT. By giving it STUN servers, it should be
connectable even without passing in `--node-ip` explicitly