### PR TITLE
Fixes bps and pps average computation.

### DIFF
--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -73,8 +73,7 @@ func GetUpdatedNodeStats(prev *livekit.NodeStats, prevAverage *livekit.NodeStats
 	if bytesInNow != prevAverage.BytesIn ||
 		bytesOutNow != prevAverage.BytesOut ||
 		packetsInNow != prevAverage.PacketsIn ||
-		packetsOutNow != prevAverage.PacketsOut ||
-		nackTotalNow != prevAverage.NackTotal {
+		packetsOutNow != prevAverage.PacketsOut {
 		computeAverage = true
 	}
 
@@ -107,7 +106,7 @@ func GetUpdatedNodeStats(prev *livekit.NodeStats, prevAverage *livekit.NodeStats
 		stats.BytesInPerSec = perSec(prevAverage.BytesIn, bytesInNow, elapsed)
 		stats.BytesOutPerSec = perSec(prevAverage.BytesOut, bytesOutNow, elapsed)
 		stats.PacketsInPerSec = perSec(prevAverage.PacketsIn, packetsInNow, elapsed)
-		stats.PacketsInPerSec = perSec(prevAverage.PacketsOut, packetsOutNow, elapsed)
+		stats.PacketsOutPerSec = perSec(prevAverage.PacketsOut, packetsOutNow, elapsed)
 		stats.NackPerSec = perSec(prevAverage.NackTotal, nackTotalNow, elapsed)
 	}
 


### PR DESCRIPTION
Exclude NACK count from being a trigger to refresh stats.
Since NACKs are updated instantaneously without having to wait for
Telemetry updates that occurs every 10s, having even a single NACK
could cause us to compute averages prematurely.

Fixes #617 