### PR TITLE
enable accept aggressive nomination by default

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -68,9 +68,9 @@ rtc:
   #     - en0
   #   excludes:
   #     - docker0
-  # # accept ice aggressive nomination, when set to true, server will accept client's aggressive nomination to update
-  # # selected candidate pair. This is useful when client has aggressive nomination in special network environment.
-  # accept_aggressive_nomination: true
+  # # some clients like chrome use aggressive nomination in special network environment to update selected candidate pair,
+  # # by default server will accept the updated nomination. If get problem with this, set to true to reject ice aggressive nomination
+  # reject_aggressive_nomination: true
 
 # when enabled, LiveKit will expose prometheus metrics on :6789/metrics
 # prometheus_port: 6789

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,7 @@ type RTCConfig struct {
 	UseExternalIP              bool             `yaml:"use_external_ip"`
 	UseICELite                 bool             `yaml:"use_ice_lite,omitempty"`
 	Interfaces                 InterfacesConfig `yaml:"interfaces"`
-	AcceptAggressiveNomination bool             `yaml:"accept_aggressive_nomination"`
+	RejectAggressiveNomination bool             `yaml:"reject_aggressive_nomination"`
 
 	// Number of packets to buffer for NACK
 	PacketBufferSize int `yaml:"packet_buffer_size,omitempty"`

--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -189,7 +189,7 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 		}
 	}
 
-	if rtcConf.AcceptAggressiveNomination {
+	if !rtcConf.RejectAggressiveNomination {
 		s.SetICEAcceptAggressiveNomination(true)
 	}
 


### PR DESCRIPTION
when enable ice lite, server should enable accept aggressive nomination to update selected candidate pair, this has no side affect when disable ice lite too, so enable aggressive nomination by default.