### PR TITLE
Fix MessageChannel leaks

### DIFF
--- a/pkg/routing/messagechannel.go
+++ b/pkg/routing/messagechannel.go
@@ -1,22 +1,24 @@
 package routing
 
 import (
+	"sync"
+
 	"google.golang.org/protobuf/proto"
 )
 
 const DefaultMessageChannelSize = 200
 
 type MessageChannel struct {
-	msgChan chan proto.Message
-	closed  chan struct{}
-	onClose func()
+	msgChan  chan proto.Message
+	onClose  func()
+	isClosed bool
+	lock     sync.RWMutex
 }
 
 func NewMessageChannel(size int) *MessageChannel {
 	return &MessageChannel{
 		// allow some buffer to avoid blocked writes
 		msgChan: make(chan proto.Message, size),
-		closed:  make(chan struct{}),
 	}
 }
 
@@ -25,22 +27,19 @@ func (m *MessageChannel) OnClose(f func()) {
 }
 
 func (m *MessageChannel) IsClosed() bool {
-	select {
-	case <-m.closed:
-		return true
-	default:
-		return false
-	}
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.isClosed
 }
 
 func (m *MessageChannel) WriteMessage(msg proto.Message) error {
-	if m.IsClosed() {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if m.isClosed {
 		return ErrChannelClosed
 	}
 
 	select {
-	case <-m.closed:
-		return ErrChannelClosed
 	case m.msgChan <- msg:
 		// published
 		return nil
@@ -55,11 +54,15 @@ func (m *MessageChannel) ReadChan() <-chan proto.Message {
 }
 
 func (m *MessageChannel) Close() {
-	if m.IsClosed() {
+	m.lock.Lock()
+	if m.isClosed {
+		m.lock.Unlock()
 		return
 	}
-	close(m.closed)
+	m.isClosed = true
 	close(m.msgChan)
+	m.lock.Unlock()
+
 	if m.onClose != nil {
 		m.onClose()
 	}

--- a/pkg/routing/routingfakes/fake_message_sink.go
+++ b/pkg/routing/routingfakes/fake_message_sink.go
@@ -13,11 +13,6 @@ type FakeMessageSink struct {
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
 	}
-	OnCloseStub        func(func())
-	onCloseMutex       sync.RWMutex
-	onCloseArgsForCall []struct {
-		arg1 func()
-	}
 	WriteMessageStub        func(protoreflect.ProtoMessage) error
 	writeMessageMutex       sync.RWMutex
 	writeMessageArgsForCall []struct {
@@ -55,38 +50,6 @@ func (fake *FakeMessageSink) CloseCalls(stub func()) {
 	fake.closeMutex.Lock()
 	defer fake.closeMutex.Unlock()
 	fake.CloseStub = stub
-}
-
-func (fake *FakeMessageSink) OnClose(arg1 func()) {
-	fake.onCloseMutex.Lock()
-	fake.onCloseArgsForCall = append(fake.onCloseArgsForCall, struct {
-		arg1 func()
-	}{arg1})
-	stub := fake.OnCloseStub
-	fake.recordInvocation("OnClose", []interface{}{arg1})
-	fake.onCloseMutex.Unlock()
-	if stub != nil {
-		fake.OnCloseStub(arg1)
-	}
-}
-
-func (fake *FakeMessageSink) OnCloseCallCount() int {
-	fake.onCloseMutex.RLock()
-	defer fake.onCloseMutex.RUnlock()
-	return len(fake.onCloseArgsForCall)
-}
-
-func (fake *FakeMessageSink) OnCloseCalls(stub func(func())) {
-	fake.onCloseMutex.Lock()
-	defer fake.onCloseMutex.Unlock()
-	fake.OnCloseStub = stub
-}
-
-func (fake *FakeMessageSink) OnCloseArgsForCall(i int) func() {
-	fake.onCloseMutex.RLock()
-	defer fake.onCloseMutex.RUnlock()
-	argsForCall := fake.onCloseArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeMessageSink) WriteMessage(arg1 protoreflect.ProtoMessage) error {
@@ -155,8 +118,6 @@ func (fake *FakeMessageSink) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
-	fake.onCloseMutex.RLock()
-	defer fake.onCloseMutex.RUnlock()
 	fake.writeMessageMutex.RLock()
 	defer fake.writeMessageMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/routing/routingfakes/fake_message_source.go
+++ b/pkg/routing/routingfakes/fake_message_source.go
@@ -9,6 +9,10 @@ import (
 )
 
 type FakeMessageSource struct {
+	CloseStub        func()
+	closeMutex       sync.RWMutex
+	closeArgsForCall []struct {
+	}
 	ReadChanStub        func() <-chan protoreflect.ProtoMessage
 	readChanMutex       sync.RWMutex
 	readChanArgsForCall []struct {
@@ -21,6 +25,30 @@ type FakeMessageSource struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeMessageSource) Close() {
+	fake.closeMutex.Lock()
+	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
+	}{})
+	stub := fake.CloseStub
+	fake.recordInvocation("Close", []interface{}{})
+	fake.closeMutex.Unlock()
+	if stub != nil {
+		fake.CloseStub()
+	}
+}
+
+func (fake *FakeMessageSource) CloseCallCount() int {
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
+	return len(fake.closeArgsForCall)
+}
+
+func (fake *FakeMessageSource) CloseCalls(stub func()) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = stub
 }
 
 func (fake *FakeMessageSource) ReadChan() <-chan protoreflect.ProtoMessage {
@@ -79,6 +107,8 @@ func (fake *FakeMessageSource) ReadChanReturnsOnCall(i int, result1 <-chan proto
 func (fake *FakeMessageSource) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
 	fake.readChanMutex.RLock()
 	defer fake.readChanMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -180,11 +182,16 @@ func (r *RoomManager) Stop() {
 }
 
 // StartSession starts WebRTC session when a new participant is connected, takes place on RTC node
-func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomName, pi routing.ParticipantInit, requestSource routing.MessageSource, responseSink routing.MessageSink) {
+func (r *RoomManager) StartSession(
+	ctx context.Context,
+	roomName livekit.RoomName,
+	pi routing.ParticipantInit,
+	requestSource routing.MessageSource,
+	responseSink routing.MessageSink,
+) error {
 	room, err := r.getOrCreateRoom(ctx, roomName)
 	if err != nil {
-		logger.Errorw("could not create room", err, "room", roomName)
-		return
+		return err
 	}
 	defer room.Release()
 
@@ -198,11 +205,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 				"nodeID", r.currentNode.Id,
 				"participant", pi.Identity,
 			)
-			if err = room.ResumeParticipant(participant, responseSink); err != nil {
-				logger.Warnw("could not resume participant", err,
-					"participant", pi.Identity)
-			}
-			return
+			return room.ResumeParticipant(participant, responseSink)
 		} else {
 			// we need to clean up the existing participant, so a new one can join
 			room.RemoveParticipant(participant.Identity())
@@ -210,17 +213,14 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 	} else if pi.Reconnect {
 		// send leave request if participant is trying to reconnect without keep subscribe state
 		// but missing from the room
-		if err = responseSink.WriteMessage(&livekit.SignalResponse{
+		_ = responseSink.WriteMessage(&livekit.SignalResponse{
 			Message: &livekit.SignalResponse_Leave{
 				Leave: &livekit.LeaveRequest{
 					CanReconnect: true,
 				},
 			},
-		}); err != nil {
-			logger.Warnw("could not restart participant", err,
-				"participant", pi.Identity)
-		}
-		return
+		})
+		return errors.New("could not restart participant")
 	}
 
 	logger.Debugw("starting RTC session",
@@ -259,8 +259,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 		AdaptiveStream:          pi.AdaptiveStream,
 	})
 	if err != nil {
-		logger.Errorw("could not create participant", err)
-		return
+		return err
 	}
 
 	// join room
@@ -270,7 +269,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 	if err = room.Join(participant, &opts, r.iceServersForRoom(room.Room), r.currentNode.Region); err != nil {
 		pLogger.Errorw("could not join room", err)
 		_ = participant.Close(true)
-		return
+		return err
 	}
 	if err = r.roomStore.StoreParticipant(ctx, roomName, participant.ToProto()); err != nil {
 		pLogger.Errorw("could not store participant", err)
@@ -309,6 +308,7 @@ func (r *RoomManager) StartSession(ctx context.Context, roomName livekit.RoomNam
 	})
 
 	go r.rtcSessionWorker(room, participant, requestSource)
+	return nil
 }
 
 // create the actual room object, to be used on RTC node
@@ -388,6 +388,7 @@ func (r *RoomManager) rtcSessionWorker(room *rtc.Room, participant types.LocalPa
 			"roomID", room.Room.Sid,
 		)
 		_ = participant.Close(true)
+		requestSource.Close()
 	}()
 	defer rtc.Recover()
 

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -189,6 +189,7 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// function exits when websocket terminates, it'll close the event reading off of response sink as well
 	defer func() {
 		pLogger.Infow("server closing WS connection", "connID", connId)
+		resSource.Close()
 		reqSink.Close()
 		close(done)
 	}()


### PR DESCRIPTION
One oversight of our MessageChannel architecture is that the source channels were never cleaned up. This has produced a slow leak for every participant that joins and leaves the room. The issue is quite visible when using a larger message buffer than the default (200) messages.

In this PR, MessageChannel can now be closed reliably by both writers and readers, and each process that handles user connection (websocket and rtc session worker) is responsible for cleaning it up.