### PR TITLE
Add back region when hydrating ParticipantInit.

### DIFF
--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -122,7 +122,7 @@ func (pi *ParticipantInit) ToStartSession(roomName livekit.RoomName, connectionI
 	}, nil
 }
 
-func ParticipantInitFromStartSession(ss *livekit.StartSession) (*ParticipantInit, error) {
+func ParticipantInitFromStartSession(ss *livekit.StartSession, region string) (*ParticipantInit, error) {
 	claims := &auth.ClaimGrants{}
 	if err := json.Unmarshal([]byte(ss.GrantsJson), claims); err != nil {
 		return nil, err
@@ -135,6 +135,7 @@ func ParticipantInitFromStartSession(ss *livekit.StartSession) (*ParticipantInit
 		Client:         ss.Client,
 		AutoSubscribe:  ss.AutoSubscribe,
 		Grants:         claims,
+		Region:         region,
 		AdaptiveStream: ss.AdaptiveStream,
 	}, nil
 }

--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -240,7 +240,7 @@ func (r *RedisRouter) startParticipantRTC(ss *livekit.StartSession, participantK
 		}
 	}
 
-	pi, err := ParticipantInitFromStartSession(ss)
+	pi, err := ParticipantInitFromStartSession(ss, r.currentNode.Region)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It was left out in the previous PR #646