### PR TITLE
Do not post close callback in ops queue if not started.

### DIFF
--- a/pkg/utils/opsqueue.go
+++ b/pkg/utils/opsqueue.go
@@ -13,6 +13,7 @@ type OpsQueue struct {
 
 	lock      sync.RWMutex
 	ops       chan func()
+	isStarted bool
 	isStopped bool
 }
 
@@ -30,6 +31,15 @@ func (oq *OpsQueue) SetLogger(logger logger.Logger) {
 }
 
 func (oq *OpsQueue) Start() {
+	oq.lock.Lock()
+	if oq.isStopped {
+		oq.lock.Unlock()
+		return
+	}
+
+	oq.isStarted = true
+	oq.lock.Unlock()
+
 	go oq.process()
 }
 
@@ -43,6 +53,13 @@ func (oq *OpsQueue) Stop() {
 	oq.isStopped = true
 	close(oq.ops)
 	oq.lock.Unlock()
+}
+
+func (oq *OpsQueue) IsStarted() bool {
+	oq.lock.RLock()
+	defer oq.lock.RUnlock()
+
+	return oq.isStarted
 }
 
 func (oq *OpsQueue) Enqueue(op func()) {

--- a/pkg/utils/opsqueue.go
+++ b/pkg/utils/opsqueue.go
@@ -32,7 +32,7 @@ func (oq *OpsQueue) SetLogger(logger logger.Logger) {
 
 func (oq *OpsQueue) Start() {
 	oq.lock.Lock()
-	if oq.isStopped {
+	if oq.isStarted {
 		oq.lock.Unlock()
 		return
 	}


### PR DESCRIPTION
Ops queue is started in `Bind()`. If `Close()` is called
when bind did not happen (because the underlying peer connection
closed before bind), the close callback does not run.

Check if ops queue is running before posting close callback
into the queue.

Not pretty, but covers this case. Need to think about it more.