### PR TITLE
Remove callbacks queue from sfu/buffer.

### DIFF
--- a/pkg/sfu/buffer/buffer_test.go
+++ b/pkg/sfu/buffer/buffer_test.go
@@ -46,7 +46,7 @@ func TestNack(t *testing.T) {
 		var wg sync.WaitGroup
 		// 5 tries
 		wg.Add(5)
-		buff.OnFeedback(func(fb []rtcp.Packet) {
+		buff.OnRtcpFeedback(func(fb []rtcp.Packet) {
 			for _, pkt := range fb {
 				switch p := pkt.(type) {
 				case *rtcp.TransportLayerNack:
@@ -96,7 +96,7 @@ func TestNack(t *testing.T) {
 			1:     0,
 		}
 		wg.Add(5 * len(expects)) // retry 5 times
-		buff.OnFeedback(func(fb []rtcp.Packet) {
+		buff.OnRtcpFeedback(func(fb []rtcp.Packet) {
 			for _, pkt := range fb {
 				switch p := pkt.(type) {
 				case *rtcp.TransportLayerNack:
@@ -194,7 +194,7 @@ func TestNewBuffer(t *testing.T) {
 			buff := NewBuffer(123, pool, pool)
 			buff.codecType = webrtc.RTPCodecTypeVideo
 			require.NotNil(t, buff)
-			buff.OnFeedback(func(_ []rtcp.Packet) {
+			buff.OnRtcpFeedback(func(_ []rtcp.Packet) {
 			})
 			buff.Bind(webrtc.RTPParameters{
 				HeaderExtensions: nil,
@@ -224,7 +224,7 @@ func TestFractionLostReport(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	buff.SetLastFractionLostReport(55)
-	buff.OnFeedback(func(fb []rtcp.Packet) {
+	buff.OnRtcpFeedback(func(fb []rtcp.Packet) {
 		for _, pkt := range fb {
 			switch p := pkt.(type) {
 			case *rtcp.ReceiverReport:

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -277,7 +277,7 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 		ObserveDuration: w.audioConfig.UpdateInterval,
 		SmoothIntervals: w.audioConfig.SmoothIntervals,
 	})
-	buff.OnFeedback(w.sendRTCP)
+	buff.OnRtcpFeedback(w.sendRTCP)
 
 	var duration time.Duration
 	switch track.RID() {


### PR DESCRIPTION
There were only two types (after inlining of audio level and TWCC)
- RTCP packets - there is already a channel for RTCP packets
- OnClose - it goes back to factory and factory just deletes the buffer
from its map.

So, removing the extra hop through ops queue.