### PR TITLE
Remove ops queue from stream tracker.

### DIFF
--- a/pkg/sfu/streamtracker.go
+++ b/pkg/sfu/streamtracker.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/logger"
 )
 
@@ -72,16 +71,13 @@ type StreamTracker struct {
 	bytesForBitrate   [4]int64
 	bitrate           [4]int64
 
-	callbacksQueue *utils.OpsQueue
-
 	isStopped bool
 }
 
 func NewStreamTracker(params StreamTrackerParams) *StreamTracker {
 	s := &StreamTracker{
-		params:         params,
-		status:         StreamStatusStopped,
-		callbacksQueue: utils.NewOpsQueue(params.Logger, "streamtracker", 50),
+		params: params,
+		status: StreamStatusStopped,
 	}
 	return s
 }
@@ -113,9 +109,7 @@ func (s *StreamTracker) maybeSetStatus(status StreamStatus) (StreamStatus, bool)
 
 func (s *StreamTracker) maybeNotifyStatus(status StreamStatus, changed bool) {
 	if changed && s.onStatusChanged != nil {
-		s.callbacksQueue.Enqueue(func() {
-			s.onStatusChanged(status)
-		})
+		s.onStatusChanged(status)
 	}
 }
 
@@ -130,7 +124,6 @@ func (s *StreamTracker) init() {
 }
 
 func (s *StreamTracker) Start() {
-	s.callbacksQueue.Start()
 }
 
 func (s *StreamTracker) Stop() {
@@ -141,8 +134,6 @@ func (s *StreamTracker) Stop() {
 		return
 	}
 	s.isStopped = true
-
-	s.callbacksQueue.Stop()
 
 	// bump generation to trigger exit of worker
 	s.generation.Inc()


### PR DESCRIPTION
It is not needed as the callback happens in a goroutine.
Also, had missed included bitrate availability change in the queue
which was inconsistent.