### PR TITLE
Set numCPUs correctly in non-linux environment

### DIFF
--- a/pkg/telemetry/prometheus/node_nonlinux.go
+++ b/pkg/telemetry/prometheus/node_nonlinux.go
@@ -4,6 +4,8 @@
 package prometheus
 
 import (
+	"runtime"
+
 	"github.com/mackerelio/go-osstat/cpu"
 )
 
@@ -21,6 +23,8 @@ func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
 
 	lastCPUTotal = cpuInfo.Total
 	lastCPUIdle = cpuInfo.Idle
+
+	numCPUs = uint32(runtime.NumCPU())
 
 	return
 }


### PR DESCRIPTION
This doesn't impact running in production, but would affect sysload selector while running locally.