### PR TITLE
Skip loading of participant before writing messages to them.

### DIFF
--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -339,11 +339,6 @@ func (s *RoomService) writeParticipantMessage(ctx context.Context, room livekit.
 		return twirpAuthError(err)
 	}
 
-	_, err := s.roomStore.LoadParticipant(ctx, room, identity)
-	if err != nil {
-		return err
-	}
-
 	return s.router.WriteParticipantRTC(ctx, room, identity, msg)
 }
 


### PR DESCRIPTION
In some implementations of the Store interface, it's possible that the
media node has not yet persisted the participant when we are trying to
send it messages. In which case we should not error on loading of the
participant.