### PR TITLE
Remove callbacks queue from sfu/DownTrack

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -580,10 +580,8 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		d.rtpStats.Stop()
 		d.logger.Debugw("rtp stats", "stats", d.rtpStats.ToString())
 
-		if d.kind == webrtc.RTPCodecTypeVideo {
-			if d.onMaxLayerChanged != nil {
-				d.onMaxLayerChanged(d, InvalidLayerSpatial)
-			}
+		if d.onMaxLayerChanged != nil && d.kind == webrtc.RTPCodecTypeVideo {
+			d.onMaxLayerChanged(d, InvalidLayerSpatial)
 		}
 
 		if d.onCloseHandler != nil {


### PR DESCRIPTION
- Connection stats callback was happening in connection stats go routine
- RTT update launches a goroutine on the receive side as it affects the
  subscriber. So, no need to queue it.
- OnBind also uses a goroutine on the receive side as it affects the subscriber.
- Changed two things
  o Move close handler to goroutine. It is better that way as it touches
the subscriber as well
  o Move max layer handling into a goroutine also so that the callback
does minimal work.

With this all the send side callback queues are removed.