### PR TITLE
Fix node ip parameter not being used

### DIFF
--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -65,7 +65,8 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 		LoggerFactory: logging.NewLoggerFactory(logger.GetLogger()),
 	}
 
-	if conf.RTC.UseExternalIP && externalIP != "" {
+	// force it to the node IPs that the user has set
+	if externalIP != "" && (conf.RTC.UseExternalIP || conf.RTC.NodeIP != "") {
 		s.SetNAT1To1IPs([]string{externalIP}, webrtc.ICECandidateTypeHost)
 	}
 

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -15,11 +15,10 @@ import (
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
 
-	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/logger"
-
 	"github.com/livekit/livekit-server/pkg/sfu/audio"
 	"github.com/livekit/livekit-server/pkg/sfu/twcc"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
 )
 
 const (


### PR DESCRIPTION
Even when node-ip was explicitly passed in, we didn't use it as the candidate IP. This fixes that.