### PR TITLE
Do not count padding packets in stream tracker.

### DIFF
--- a/pkg/sfu/streamtracker_test.go
+++ b/pkg/sfu/streamtracker_test.go
@@ -32,7 +32,7 @@ func TestStreamTracker(t *testing.T) {
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
 		// observe first packet
-		tracker.Observe(1, 0, 0, 0)
+		tracker.Observe(1, 0, 20, 10)
 
 		testutils.WithTimeout(t, func() string {
 			if callbackCalled.Load() {
@@ -53,7 +53,7 @@ func TestStreamTracker(t *testing.T) {
 		tracker.Start()
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
-		tracker.Observe(1, 0, 0, 0)
+		tracker.Observe(1, 0, 20, 10)
 		testutils.WithTimeout(t, func() string {
 			if tracker.Status() == StreamStatusActive {
 				return ""
@@ -89,7 +89,7 @@ func TestStreamTracker(t *testing.T) {
 		tracker.Start()
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
-		tracker.Observe(1, 0, 0, 0)
+		tracker.Observe(1, 0, 20, 10)
 		testutils.WithTimeout(t, func() string {
 			if tracker.Status() == StreamStatusActive {
 				return ""
@@ -100,11 +100,11 @@ func TestStreamTracker(t *testing.T) {
 
 		tracker.maybeSetStatus(StreamStatusStopped)
 
-		tracker.Observe(2, 0, 0, 0)
+		tracker.Observe(2, 0, 20, 10)
 		tracker.detectChanges()
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
-		tracker.Observe(3, 0, 0, 0)
+		tracker.Observe(3, 0, 20, 10)
 		tracker.detectChanges()
 		require.Equal(t, StreamStatusActive, tracker.Status())
 
@@ -114,7 +114,7 @@ func TestStreamTracker(t *testing.T) {
 	t.Run("changes to inactive when paused", func(t *testing.T) {
 		tracker := newStreamTracker(5, 60, 500*time.Millisecond)
 		tracker.Start()
-		tracker.Observe(1, 0, 0, 0)
+		tracker.Observe(1, 0, 20, 10)
 		testutils.WithTimeout(t, func() string {
 			if tracker.Status() == StreamStatusActive {
 				return ""
@@ -140,7 +140,7 @@ func TestStreamTracker(t *testing.T) {
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
 		// observe first packet
-		tracker.Observe(1, 0, 0, 0)
+		tracker.Observe(1, 0, 20, 10)
 
 		testutils.WithTimeout(t, func() string {
 			if callbackCalled.Load() == 1 {
@@ -154,10 +154,10 @@ func TestStreamTracker(t *testing.T) {
 		require.Equal(t, uint32(1), callbackCalled.Load())
 
 		// observe a few more
-		tracker.Observe(2, 0, 0, 0)
-		tracker.Observe(3, 0, 0, 0)
-		tracker.Observe(4, 0, 0, 0)
-		tracker.Observe(5, 0, 0, 0)
+		tracker.Observe(2, 0, 20, 10)
+		tracker.Observe(3, 0, 20, 10)
+		tracker.Observe(4, 0, 20, 10)
+		tracker.Observe(5, 0, 20, 10)
 		tracker.detectChanges()
 
 		// should still be active
@@ -168,7 +168,7 @@ func TestStreamTracker(t *testing.T) {
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
 		// first packet after reset
-		tracker.Observe(1, 0, 0, 0)
+		tracker.Observe(1, 0, 20, 10)
 
 		testutils.WithTimeout(t, func() string {
 			if callbackCalled.Load() == 2 {


### PR DESCRIPTION
There are cases where publisher uses padding only packets
in a layer to probe the channel. Treating those as valid
layer packets makes stream tracker declare that the layer
is active where in reality, it is not.

Also, removing check for out-of-order packets. Out-of-order
packets can happen and should be counted in bitrate calculation.

There is the extreme case of heavy loss which might skew it, but
that is an extreme case.