### PR TITLE
Change state to `JOINED` before sending `JoinResponse`

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -502,9 +502,6 @@ func (p *ParticipantImpl) HandleOffer(sdp webrtc.SessionDescription) (answer web
 		}
 	}
 
-	if p.State() == livekit.ParticipantInfo_JOINING {
-		p.updateState(livekit.ParticipantInfo_JOINED)
-	}
 	prometheus.ServiceOperationCounter.WithLabelValues("answer", "success", "").Add(1)
 
 	return

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -37,6 +37,10 @@ func (p *ParticipantImpl) SendJoinResponse(
 	iceServers []*livekit.ICEServer,
 	region string,
 ) error {
+	if p.State() == livekit.ParticipantInfo_JOINING {
+		p.updateState(livekit.ParticipantInfo_JOINED)
+	}
+
 	// send Join response
 	return p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_Join{

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -525,7 +525,7 @@ func (r *Room) SetMetadata(metadata string) {
 func (r *Room) sendRoomUpdateLocked() {
 	// Send update to participants
 	for _, p := range r.participants {
-		if !p.IsReady() {
+		if p.State() == livekit.ParticipantInfo_DISCONNECTED {
 			continue
 		}
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -525,7 +525,7 @@ func (r *Room) SetMetadata(metadata string) {
 func (r *Room) sendRoomUpdateLocked() {
 	// Send update to participants
 	for _, p := range r.participants {
-		if p.State() == livekit.ParticipantInfo_DISCONNECTED {
+		if !p.IsReady() {
 			continue
 		}
 

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -290,7 +290,7 @@ func (s *StreamTrackerManager) addAvailableLayer(layer int32) {
 	layers := s.availableLayers
 	s.lock.Unlock()
 
-	s.logger.Debugw("available layers changed - layer seen", "layers", layers)
+	s.logger.Debugw("available layers changed - layer seen", "added", layer, "layers", layers)
 
 	if s.onAvailableLayersChanged != nil {
 		s.onAvailableLayersChanged(layers)
@@ -309,7 +309,7 @@ func (s *StreamTrackerManager) removeAvailableLayer(layer int32) {
 	s.availableLayers = newLayers
 	s.lock.Unlock()
 
-	s.logger.Debugw("available layers changed - layer gone", "layers", newLayers)
+	s.logger.Debugw("available layers changed - layer gone", "removed", layer, "layers", newLayers)
 
 	// need to immediately switch off unavailable layers
 	if s.onAvailableLayersChanged != nil {


### PR DESCRIPTION
Previously, it was changed when handling offer of up stream peer connection. But, it is not the optimal spot for subscriber as primary.

Question: The state change triggers callbacks. Should we change state after sending join response, maybe?