### PR TITLE
Improve list-nodes command output 

### DIFF
--- a/cmd/server/commands.go
+++ b/cmd/server/commands.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
@@ -153,47 +155,59 @@ func listNodes(c *cli.Context) error {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
+	table.SetRowLine(true)
+	table.SetAutoWrapText(false)
 	table.SetHeader([]string{
 		"ID", "IP Address", "Region",
-		"CPUs", "CPU Usage", "Load",
-		"Clients", "Rooms", "Tracks In/Out",
-		"Bytes In/Out", "Packets In/Out",
-		"Nack", "Retransmits",
-		"Bps In/Out", "Pps In/Out", "Nack/Sec",
-		"Started At", "Updated At",
+		"CPUs", "CPU Usage /\nLoad Avg",
+		"Rooms", "Clients /\nTracks In/Out",
+		"Bytes/s In/Out /\nBytes Total", "Packets/s In/Out /\nPackets Total",
+		"Nack/s /\nNack Total", "Retrans/s /\nRetrans Total",
+		"Started At /\nUpdated At",
 	})
+	table.SetColumnAlignment([]int{
+		tablewriter.ALIGN_CENTER, tablewriter.ALIGN_CENTER, tablewriter.ALIGN_CENTER,
+		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
+		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
+		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
+		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
+		tablewriter.ALIGN_CENTER,
+	})
+
 	for _, node := range nodes {
 		stats := node.Stats
 
+		// Id and state
+		idAndState := fmt.Sprintf("%s\n(%s)", node.Id, node.State.Enum().String())
+
 		// System stats
 		cpus := strconv.Itoa(int(stats.NumCpus))
-		cpuUsage := fmt.Sprintf("%.2f %%", stats.CpuLoad*100)
-		loadAvg := fmt.Sprintf("%.2f, %.2f, %.2f", stats.LoadAvgLast1Min, stats.LoadAvgLast5Min, stats.LoadAvgLast15Min)
+		cpuUsageAndLoadAvg := fmt.Sprintf("%.2f %%\n%.2f %.2f %.2f", stats.CpuLoad*100,
+			stats.LoadAvgLast1Min, stats.LoadAvgLast5Min, stats.LoadAvgLast15Min)
 
 		// Room stats
-		clients := strconv.Itoa(int(stats.NumClients))
 		rooms := strconv.Itoa(int(stats.NumRooms))
-		tracks := fmt.Sprintf("%d / %d", stats.NumTracksIn, stats.NumTracksOut)
+		clientsAndTracks := fmt.Sprintf("%d\n%d / %d", stats.NumClients, stats.NumTracksIn, stats.NumTracksOut)
 
 		// Packet stats
-		bytes := fmt.Sprintf("%d / %d", stats.BytesIn, stats.BytesOut)
-		packets := fmt.Sprintf("%d / %d", stats.PacketsIn, stats.PacketsOut)
-		nack := strconv.Itoa(int(stats.NackTotal))
-		retransmit := strconv.Itoa(int(stats.RetransmitPacketsOut))
-		bps := fmt.Sprintf("%.2f / %.2f", stats.BytesInPerSec, stats.BytesOutPerSec)
-		packetsPerSec := fmt.Sprintf("%.2f / %.2f", stats.PacketsInPerSec, stats.PacketsOutPerSec)
-		nackPerSec := fmt.Sprintf("%f", stats.NackPerSec)
+		bytes := fmt.Sprintf("%sps / %sps\n%s / %s", humanize.Bytes(uint64(stats.BytesInPerSec)), humanize.Bytes(uint64(stats.BytesOutPerSec)),
+			humanize.Bytes(stats.BytesIn), humanize.Bytes(stats.BytesOut))
+		packets := fmt.Sprintf("%s / %s\n%s / %s", humanize.Comma(int64(stats.PacketsInPerSec)), humanize.Comma(int64(stats.PacketsOutPerSec)),
+			strings.TrimSpace(humanize.SIWithDigits(float64(stats.PacketsIn), 2, "")), strings.TrimSpace(humanize.SIWithDigits(float64(stats.PacketsOut), 2, "")))
+		nacks := fmt.Sprintf("%.2f\n%s", stats.NackPerSec, strings.TrimSpace(humanize.SIWithDigits(float64(stats.NackTotal), 2, "")))
+		retransmit := fmt.Sprintf("%.2f\n%s", stats.RetransmitPacketsOutPerSec, strings.TrimSpace(humanize.SIWithDigits(float64(stats.RetransmitPacketsOut), 2, "")))
 
-		startedAt := time.Unix(stats.StartedAt, 0).String()
-		updatedAt := time.Unix(stats.UpdatedAt, 0).String()
+		// Date
+		startedAndUpdated := fmt.Sprintf("%s\n%s", time.Unix(stats.StartedAt, 0).UTC().UTC().Format("2006-01-02 15:04:05"),
+			time.Unix(stats.UpdatedAt, 0).UTC().Format("2006-01-02 15:04:05"))
 
 		table.Append([]string{
-			node.Id, node.Ip, node.Region,
-			cpus, cpuUsage, loadAvg,
-			clients, rooms, tracks,
-			bytes, packets, nack, retransmit,
-			bps, packetsPerSec, nackPerSec,
-			startedAt, updatedAt,
+			idAndState, node.Ip, node.Region,
+			cpus, cpuUsageAndLoadAvg,
+			rooms, clientsAndTracks,
+			bytes, packets,
+			nacks, retransmit,
+			startedAndUpdated,
 		})
 	}
 	table.Render()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/bep/debounce v1.2.0
+	github.com/dustin/go-humanize v1.0.0
 	github.com/elliotchance/orderedmap v1.4.0
 	github.com/gammazero/deque v0.1.0
 	github.com/gammazero/workerpool v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/channels v1.1.0 h1:F1taHcn7/F0i8DYqKXJnyhJcVpp2kgFcNePxXtnyu4k=
 github.com/eapache/channels v1.1.0/go.mod h1:jMm2qB5Ubtg9zLd+inMZd2/NUvXgzmWXsDaLyQIGfH0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=


### PR DESCRIPTION
I tidied up `list-nodes` command output:
- made the table narrower (to fit on the screen);
- made numbers humanized;
- added nodes state (useful with SHUTTING_DOWN state);
- added retransmitted packets per second.

Then:
```
+-------------+---------------+--------+------+-----------+------------------+---------+-------+---------------+----------------------+-----------------+------+-------------------------+-------------------+----------+-------------------------------+-------------------------------+
|     ID      |  IP ADDRESS   | REGION | CPUS | CPU USAGE |       LOAD       | CLIENTS | ROOMS | TRACKS IN/OUT |     BYTES IN/OUT     | PACKETS IN/OUT  | NACK |       BPS IN/OUT        |    PPS IN/OUT     | NACK/SEC |          STARTED AT           |          UPDATED AT           |
+-------------+---------------+--------+------+-----------+------------------+---------+-------+---------------+----------------------+-----------------+------+-------------------------+-------------------+----------+-------------------------------+-------------------------------+
| ND_pFsCmxfS | 51.250.71.237 |        |    4 | 38.66 %   | 0.35, 0.13, 0.31 |     166 |    84 | 164 / 160     | 124311077 / 86336685 | 162823 / 110769 |    0 | 6592053.00 / 4745583.00 | 8630.70 / 6077.30 | 0.000000 | 2022-05-11 11:45:51 +0000 UTC | 2022-05-11 11:47:07 +0000 UTC |
+-------------+---------------+--------+------+-----------+------------------+---------+-------+---------------+----------------------+-----------------+------+-------------------------+-------------------+----------+-------------------------------+-------------------------------+
```

Now:
```
+-------------+---------------+--------+------+----------------+-------+---------------+--------------------+---------------------+------------+---------------+---------------------+
|     ID      |  IP ADDRESS   | REGION | CPUS |  CPU USAGE /   | ROOMS |   CLIENTS /   |  BYTES/S IN/OUT /  | PACKETS/S IN/OUT /  |  NACK/S /  |  RETRANS/S /  |    STARTED AT /     |
|             |               |        |      |    LOAD AVG    |       | TRACKS IN/OUT |    BYTES TOTAL     |    PACKETS TOTAL    | NACK TOTAL | RETRANS TOTAL |     UPDATED AT      |
+-------------+---------------+--------+------+----------------+-------+---------------+--------------------+---------------------+------------+---------------+---------------------+
| ND_pFsCmxfS | 51.250.71.237 |        |    4 |        35.50 % |   100 |           200 | 12 MBps / 9.4 MBps |     16,029 / 11,962 |       0.00 |          0.00 | 2022-05-11 11:18:04 |
|  (SERVING)  |               |        |      | 1.92 1.10 0.46 |       |     200 / 200 |    543 MB / 401 MB | 711.53 k / 513.15 k |          7 |             6 | 2022-05-11 11:19:58 |
+-------------+---------------+--------+------+----------------+-------+---------------+--------------------+---------------------+------------+---------------+---------------------+

```
